### PR TITLE
Add AI-assistant knowledge base and refresh README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ config/miners.yml
 config/mongoid.yml
 ._*
 /coverage
+
+# Override the global `docs/*` ignore so the AI-assistant docs in docs/*.md
+# track with the repo. The global rule still covers anything non-Markdown
+# that happens to land in docs/ (e.g. generated coverage HTML).
+!docs/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,316 @@
+# AGENTS.md — `cgminer_manager`
+
+Consolidated context for AI coding assistants. For end-user docs, see [`README.md`](README.md). For release history and the 0.x Rails → 1.0 Sinatra migration, see [`CHANGELOG.md`](CHANGELOG.md) and [`MIGRATION.md`](MIGRATION.md). For deep dives on any topic below, see [`docs/`](docs/) (start with [`docs/index.md`](docs/index.md)).
+
+## Table of contents
+
+- [What this is](#what-this-is)
+- [Repo layout](#repo-layout)
+- [How the pieces fit together](#how-the-pieces-fit-together)
+- [Conventions that matter when editing code](#conventions-that-matter-when-editing-code)
+- [Running tests and lint](#running-tests-and-lint)
+- [Adding a new HTTP route](#adding-a-new-http-route)
+- [Adding a new graph metric](#adding-a-new-graph-metric)
+- [Adding a new admin command](#adding-a-new-admin-command)
+- [Ruby version support](#ruby-version-support)
+- [Gotchas worth knowing up front](#gotchas-worth-knowing-up-front)
+- [Release process](#release-process)
+- [Where to look for deeper context](#where-to-look-for-deeper-context)
+
+---
+
+## What this is
+
+<!-- metadata: overview, stack, purpose -->
+
+A **Sinatra + Puma web UI** for operating cgminer mining rigs. Sits at the top of a three-gem chain:
+
+- `cgminer_api_client` (TCP client for cgminer's JSON API) — used for write-path ops (pool management, admin RPC).
+- `cgminer_monitor` (daemon + MongoDB-backed HTTP API) — used for read-path data (dashboard, graphs, per-miner snapshots).
+- `cgminer_manager` (this repo) — orchestrates the UI on top of both.
+
+**Stack:** Ruby 3.2+, Sinatra 4.0, sinatra-contrib, Puma 6.4, HAML 6, `http` gem 5.2, `rack-protection` 4.0. No MongoDB, no Rails, no asset pipeline. ~1.5K SLOC in `lib/`, ~2.2K in `spec/`.
+
+**Execution model:** `cgminer_manager run` starts a single foreground process with Puma embedded. SIGTERM/SIGINT → graceful shutdown, exit 0. Config errors → exit 2. Unknown CLI verb → exit 64. No background workers, no daemonize, no PID file.
+
+## Repo layout
+
+<!-- metadata: directory-structure, file-organization -->
+
+```
+├── bin/cgminer_manager             # CLI: run / doctor / version (packaged)
+├── lib/cgminer_manager.rb          # require graph only
+├── lib/cgminer_manager/
+│   ├── admin_auth.rb               # AdminAuth middleware + ConditionalAuthenticityToken
+│   ├── cgminer_commander.rb        # Thread-cap fan-out for fleet admin RPC
+│   ├── cli.rb                      # Verb dispatch + exit codes
+│   ├── config.rb                   # Data.define Config from env + validation
+│   ├── errors.rb                   # Error, ConfigError, MonitorError { Connection, Api }, PoolManagerError::DidNotConverge
+│   ├── fleet_query_result.rb       # FleetQueryEntry + FleetQueryResult (Data.define)
+│   ├── fleet_write_result.rb       # FleetWriteEntry + FleetWriteResult (Data.define)
+│   ├── http_app.rb                 # Sinatra app: 14 routes, helpers, view-model builders (~700 LOC)
+│   ├── logger.rb                   # Structured JSON/text logger (module singleton, thread-safe)
+│   ├── monitor_client.rb           # HTTP client for cgminer_monitor /v2/*
+│   ├── pool_manager.rb             # PoolManager + MinerEntry + PoolActionResult (Data.define)
+│   ├── server.rb                   # Orchestrator: signals, Puma launcher, shutdown
+│   ├── snapshot_adapter.rb         # Monitor envelope → legacy HAML shape translation
+│   ├── version.rb                  # VERSION = "1.2.0"
+│   └── view_miner.rb               # ViewMiner + ViewMinerPool (Data.define value types)
+├── views/                          # HAML templates (packaged)
+│   ├── layout.haml, _header.haml, _footer.haml
+│   ├── manager/ (_summary, _miner_pool, _admin, index)
+│   ├── miner/ (_summary, _devices, _pools, _stats, _admin, show)
+│   ├── shared/ (_fleet_query, _fleet_write, _manage_pools, _miner_*, _warnings, graphs/*)
+│   └── errors/ (404, 500)
+├── public/                         # Static assets served by Puma (packaged): css, js, audio, screenshots, fonts
+├── config/
+│   ├── miners.yml.example          # [{ host, port, [label] }]
+│   └── puma.rb                     # For direct `puma`/`rackup`; NOT used by `run` (Server builds its own launcher)
+├── config.ru                       # Rack entrypoint — matches build_puma_launcher without signals/shutdown
+├── spec/                           # RSpec unit + integration (NOT packaged)
+│   ├── cgminer_manager/            # Unit, one per lib/ file
+│   ├── integration/                # HTTP-level tagged :integration
+│   ├── fixtures/monitor/*.json     # Canned monitor /v2/* responses
+│   └── support/ (cgminer_fixtures, fake_cgminer, monitor_stubs)
+├── dev/screenshots/                # Scripted Playwright harness; launches 6 real TCP listeners + fake monitor
+├── docs/                           # AI-assistant knowledge base (you're reading from here)
+├── .github/workflows/
+│   ├── ci.yml                      # lint + test matrix (3.2/3.3/3.4) + integration jobs
+│   └── nightly.yml                 # Ruby 4.0 / head experimental
+├── .rubocop.yml                    # TargetRubyVersion 3.2; Metrics/ClassLength 550 for HttpApp
+├── .rspec, .ruby-version
+├── Rakefile                        # default: [rubocop, spec]
+├── Dockerfile                      # multi-stage, ruby:3.4-slim
+├── docker-compose.yml              # manager + monitor + mongo
+├── Gemfile
+├── cgminer_manager.gemspec
+├── CHANGELOG.md                    # Keep-a-Changelog; 1.2.0 → 1.0.0
+├── MIGRATION.md                    # 0.x Rails → 1.0 Sinatra upgrade
+├── README.md
+└── LICENSE.txt                     # MIT
+```
+
+**Packaged in the gem** (gemspec `spec.files`): `lib/**/*`, `views/**/*`, `public/**/*`, `bin/*`, `config/*.example`, `config/puma.rb`, `config.ru`, README, MIGRATION, CHANGELOG, LICENSE. **Not packaged:** `spec/`, `dev/`, `.github/`, `Dockerfile`, `docker-compose.yml`, `docs/`.
+
+## How the pieces fit together
+
+<!-- metadata: architecture, dataflow -->
+
+```
+bin/cgminer_manager run
+      │
+      ▼
+   CLI → Server → Puma → HttpApp (Sinatra)
+                            │
+                            ├── Rack::Session::Cookie ─┐
+                            ├── AdminAuth              │ middleware
+                            └── ConditionalAuthenticityToken ┘
+                            │
+                            ├── read path: MonitorClient ── HTTP ──> cgminer_monitor ── Mongo (not ours)
+                            │                                    └── /v2/miners, /v2/miners/:id/:type, /v2/graph_data/:metric
+                            │
+                            └── write path: CgminerCommander ── TCP (via cgminer_api_client) ──> cgminer
+                                            PoolManager      ── TCP (via cgminer_api_client) ──> cgminer
+```
+
+**Key structural facts:**
+
+1. **Two upstreams with different transports.** HTTP to `cgminer_monitor` for reads, TCP direct to cgminer for writes. The manager never reads cgminer directly for dashboard tiles (that's monitor's job) and never writes to Mongo.
+2. **Single-process, foreground, no background workers.** Supervisor-driven.
+3. **`HttpApp` has class-level state** set by `Server#configure_http_app` at boot: `.monitor_url`, `.miners_file`, `.stale_threshold_seconds`, `.pool_thread_cap`, plus a memoized `.configured_miners` cache. Tests must reset the cache between examples.
+4. **`Config` is immutable** (`Data.define`). Validated at boot. **Exception:** `AdminAuth` reads `CGMINER_MANAGER_ADMIN_USER`/`_PASSWORD` per-request — deliberate, so dev harnesses can toggle auth without restart.
+5. **`CgminerApiClient::Miner.to_s` is monkey-patched** at the top of `http_app.rb` to return `"host:port"`. Upstream doesn't define it; `respond_to_missing?` excludes `to_*`, so it's a safe host-side addition. Makes `FleetWriteEntry.miner` and `MinerEntry.miner` display stable identifiers.
+6. **Admin surface has 4 defensive layers.** In order: (a) CSRF via `ConditionalAuthenticityToken`, (b) optional Basic Auth via `AdminAuth` — valid Basic Auth bypasses CSRF, (c) scope restrictions on hardware-tuning verbs (refuse `scope=all`), (d) per-request audit logging threaded by `request_id`. The typed-allowlist on `/manager/admin/:command` is **ergonomic** (UI buttons), not defensive — anyone who can reach `/admin/run` can run any cgminer verb.
+7. **Thread-cap fan-out pattern** appears three times: `HttpApp#fetch_snapshots_for`, `CgminerCommander#fan_out`, `PoolManager#run_each`. All three use `Queue` + fixed worker count + `Mutex`-protected results. Default cap is 8 via `POOL_THREAD_CAP`.
+8. **No OpenAPI spec** (unlike `cgminer_monitor`). If you add one, also add a CI parity check.
+
+## Conventions that matter when editing code
+
+<!-- metadata: coding-style, conventions, best-practices -->
+
+### Ruby style
+
+- **Every file starts with `# frozen_string_literal: true`.** Enforced by RuboCop. New files too.
+- **`Data.define` for immutable value objects**, not `Struct` or custom classes. See `Config`, `ViewMiner`, `FleetQueryResult`/`Entry`, `FleetWriteResult`/`Entry`, `PoolManager::MinerEntry`, `PoolActionResult`.
+- **Endless method definitions** are the preferred shape for one-liners (`def method = ...`). Used extensively in `MonitorClient`, `Logger`, `ViewMiner`, the Data.define helpers, `HttpApp` URL builders.
+- **Explicit `StandardError` in bare rescues.** The one `rescue Exception` in the codebase is in `Server#start_puma_thread` and carries a RuboCop disable comment — it's intentional there so Puma crashes reliably push to `@stop`.
+- **Structured logging everywhere.** `Logger.info(event: 'foo.bar', ...)` with keyword args. Every event has an `event:` key for grep-ability. No `warn`/`puts`/`$stderr` in `lib/`. The only direct `warn` is in `bin/cgminer_manager`'s unknown-verb branch, `Config.resolve_session_secret`'s ephemeral-secret fallback, and `CLI#run`'s `rescue ConfigError`.
+- **`YAML.safe_load_file`**, not `YAML.load_file`.
+- **Don't mutate `Config` at runtime.**
+
+### RuboCop
+
+- `.rubocop.yml` disables `Style/Documentation` and tunes `Metrics/*`: `MethodLength` max 25, `ClassLength` max 550 (for `HttpApp`), `AbcSize` max 25.
+- `Metrics/BlockLength` excludes `spec/**/*` and `lib/cgminer_manager/http_app.rb` (Sinatra route blocks).
+- Correctness cops stay on.
+- `Naming/MethodParameterName` allowed names: `ok`, `ts`, `v` (Mongo-idiom; inherited from the sibling repos, not used much here).
+
+### Commit style
+
+- **One commit per logical step.** Multi-step changes should land with one commit per step, and `bundle exec rake` should pass before each commit.
+- Imperative mood ("Add X", "Fix Y"). Look at recent `git log` for the project's voice — conventional-commits-ish (`feat(...)`, `fix(...)`) when describing releases, free-form otherwise.
+
+### Error handling
+
+- New errors should subclass `CgminerManager::Error` or one of its existing children (`ConfigError`, `MonitorError`, `MonitorError::ConnectionError`, `MonitorError::ApiError`).
+- **Rescue narrowly.** `MonitorClient#get` catches three specific transport exceptions; `PoolManager#safe_call` catches three cgminer_api_client error classes. Don't add broad `rescue StandardError` without a specific reason.
+- **Don't silently swallow.** `HttpApp#safe_fetch` returns `{error: msg}` on `MonitorError` rescue, which the partial then renders as a "data source unavailable" placeholder. That's *structural* handling, not a swallow. Follow that pattern.
+
+### Testing
+
+- **Unit specs live at `spec/cgminer_manager/**`**, one file per `lib/` file (roughly).
+- **Integration specs at `spec/integration/`**, tagged `:integration`. They use `Rack::Test::Methods` against `HttpApp` — no Puma spin-up.
+- **Monitor calls are stubbed with WebMock**. See `spec/support/monitor_stubs.rb` for helpers that stub `/v2/*` with fixture JSON.
+- **cgminer calls use `FakeCgminer`** (the shared in-process TCP server from `spec/support/fake_cgminer.rb`).
+- **Between examples that touch `HttpApp.configured_miners`, call `HttpApp.reset_configured_miners!`** — or use `HttpApp.configure_for_test!(...)` which does that for you.
+- **Warnings are deliberately on** in `.rspec`. Keep the suite warning-clean.
+- `config.order = :random` — specs must be order-independent.
+- `mocks.verify_partial_doubles = true` — doubles must match real signatures.
+
+## Running tests and lint
+
+<!-- metadata: testing, local-dev, commands -->
+
+```sh
+bundle install
+bundle exec rake                                     # rubocop + rspec (full suite)
+bundle exec rspec --tag ~integration                 # unit only (what the CI test matrix runs)
+bundle exec rspec --tag integration                  # integration only
+bundle exec rspec path/to/spec.rb:123                # single example
+bundle exec rubocop                                  # lint only
+bundle exec rubocop -A                               # lint + auto-correct
+```
+
+Coverage is always on (SimpleCov, enforced at the default rake task via `ENFORCE_COVERAGE=1`). Reports in `coverage/` — `.gitignore`d.
+
+**No external services required for `bundle exec rake`.** No MongoDB, no live monitor, no cgminer. Everything is WebMock + FakeCgminer in-process.
+
+**Regenerating screenshots:**
+
+```sh
+cd dev/screenshots
+./boot.sh    # launches 6 fake cgminers + fake monitor + manager
+# Playwright drives the UI via scenario.rb
+./teardown.sh
+```
+
+**Refreshing monitor fixtures:**
+
+```sh
+CGMINER_MONITOR_URL=http://monitor.local:9292 bundle exec rake spec:refresh_monitor_fixtures
+```
+
+## Adding a new HTTP route
+
+<!-- metadata: extending, how-to -->
+
+1. **Add the Sinatra route** in `lib/cgminer_manager/http_app.rb`. Match the existing section ordering (Health → Prometheus-ish → Miners → Miner detail → Graph data → Admin → OpenAPI/Docs → Errors).
+2. **Decide on CSRF and Basic Auth shape.** Non-admin POSTs need CSRF. Admin POSTs match the `%r{\A/(manager|miner/[^/]+)/admin(/|\z)}` path regex and get both CSRF and Basic Auth gating automatically.
+3. **Write an integration spec** in `spec/integration/` using `Rack::Test::Methods`. Tag `:integration`. Cover happy path, error cases, auth/CSRF cases if it's an admin POST.
+4. **Update `interfaces.md`** in `docs/` with the new route entry — same column shape as the existing table.
+5. **No OpenAPI update needed** (we don't have one). If we add one later, this step becomes required.
+
+## Adding a new graph metric
+
+<!-- metadata: extending, how-to -->
+
+1. **Add the column projection** to `GRAPH_METRIC_PROJECTIONS` in `lib/cgminer_manager/http_app.rb`: metric name → ordered list of column names (the first should be `ts`).
+2. **Make sure monitor exposes the columns.** The projection reads from monitor's `/v2/graph_data/:metric` response `fields`/`data`. If monitor doesn't return a column you're projecting, the projection fills `nil` for that slot.
+3. **Add a HAML partial** under `views/shared/graphs/_<metric>.haml` if the metric needs a distinct Chart.js canvas. Follow the existing 6-graph pattern (`_hashrate.haml`, `_temperature.haml`, etc.).
+4. **Wire the partial into `views/manager/_summary.haml`** (dashboard) and/or per-miner views.
+5. **Test via `spec/integration/graph_data_spec.rb`** or add a new spec.
+
+## Adding a new admin command
+
+<!-- metadata: extending, how-to -->
+
+### If it's a typed button (one-click, predictable output):
+
+1. Add the verb to `ALLOWED_ADMIN_QUERIES` (for reads) or `ALLOWED_ADMIN_WRITES` (for writes) in `http_app.rb`.
+2. Add a method to `CgminerCommander` — `def foo = fan_out_query(:foo)` for reads, or `def foo! = fan_out_write { |m| m.query(:foo) }` for writes.
+3. Add the UI button to `views/manager/_admin.haml` and `views/miner/_admin.haml`.
+4. Add a spec in `spec/cgminer_manager/cgminer_commander_spec.rb` or an integration spec in `spec/integration/admin_spec.rb`.
+
+### If it's a hardware-tuning verb (must NOT target scope=all):
+
+Add the verb to `SCOPE_RESTRICTED_VERBS` in `http_app.rb` *before* anything else. The server-side regex + UI disabling of the "all" scope both key off this list.
+
+### If users should reach it only via raw RPC:
+
+No code change needed. Users can POST `command=<verb>` to `/manager/admin/run`. The `ADMIN_RAW_COMMAND_PATTERN` (`/\A[a-z][a-z0-9_+]*\z/`) will accept any well-formed cgminer verb. Still consider scope restrictions.
+
+## Ruby version support
+
+<!-- metadata: runtime, compatibility -->
+
+- **Minimum: Ruby 3.2.** Enforced by the gemspec. `Data.define` needs 3.2+; endless method defs need 3.0+.
+- **CI-tested: 3.2 / 3.3 / 3.4** (must pass).
+- **Best-effort: 4.0, head** via the nightly workflow.
+- **Local dev pin:** `.ruby-version` = 4.0.2.
+
+**Sharp edges:**
+- `parallel` gem pinned `< 2.0` in the Gemfile because parallel 2.x requires Ruby 3.3. Transitive dep of RuboCop.
+- Haml 6 (not 5) is required — the `html_safe?`-stamping helpers (`raw`, `html_safe`, `render_partial`) depend on Haml 6's escape semantics.
+
+## Gotchas worth knowing up front
+
+<!-- metadata: caveats, surprises -->
+
+1. **Signal handlers must be installed before Puma boots, then reinstalled after.** Puma's `Launcher#run` calls `setup_signals` synchronously inside the Puma thread, overwriting any process-global SIGTERM/SIGINT traps. `Server#run` works around this by installing early, waiting on `@booted.pop` (signaled by `launcher.events.on_booted`), then reinstalling. Plus `raise_exception_on_sigterm false` to prevent Puma from raising SignalException inside its thread. If you change how Puma starts, re-verify SIGTERM routes through `@stop`.
+
+2. **`CgminerApiClient::Miner#to_s` is monkey-patched at the top of `http_app.rb`** to return `"host:port"`. Upstream doesn't define it. If you see `Miner.to_s` returning something like `"#<CgminerApiClient::Miner:0x00007f...>"`, the monkey patch isn't loaded.
+
+3. **`AdminAuth` reads env per-request, not at boot.** Intentional — lets dev harnesses toggle auth without restart. Empty strings = unset. If you want Basic Auth enabled, both `CGMINER_MANAGER_ADMIN_USER` and `CGMINER_MANAGER_ADMIN_PASSWORD` must be non-empty.
+
+4. **`ConditionalAuthenticityToken` bypasses CSRF when Basic Auth passed.** Valid static Basic Auth is strictly stronger proof than session cookie + CSRF. This lets operators curl admin routes during incidents without scraping a token first. If you see admin POSTs inexplicably succeeding without a CSRF token, check whether Basic Auth is being sent.
+
+5. **`SnapshotAdapter.sanitize_key` preserves `%`.** It does `downcase.tr(' ', '_').to_sym` only. `"Device Hardware%"` → `:'device_hardware%'`. That matches `cgminer_api_client::Miner#sanitized` (what the legacy partials expect), **not** monitor's Poller normalization (which maps `%` → `_pct` for time-series sample metadata). Don't "fix" the adapter to match the Poller; the partials will break.
+
+6. **`HttpApp.configured_miners` is lazily memoized at first request, not at boot.** If miners.yml has a bad shape, the error surfaces as an HTTP 500 on first hit rather than a boot failure. `bin/cgminer_manager doctor` validates eagerly; `run` doesn't. (Flagged in `review_notes.md`.)
+
+7. **`Config#monitor_timeout` is declared but not plumbed through.** `MonitorClient.new` is called without `timeout_ms:`, so it uses its hardcoded 2-second default. `MONITOR_TIMEOUT_MS` env var does nothing today. (Flagged in `review_notes.md`.)
+
+8. **Raw admin RPC splits `args` on comma before escaping.** `CgminerCommander#raw!` does `args.to_s.split(',')` and passes the positional array to `Miner#query`. Commas inside argument values are not escapable through this form. Not a practical limitation for any real cgminer verb. Matches the README "raw RPC arg escaping caveat".
+
+9. **Exit code 2 for config errors, not 78.** `cgminer_monitor` uses `78` (`EX_CONFIG`). Manager uses `2`. Not consistent; not worth fixing retroactively.
+
+10. **`config/puma.rb` exists but is not used by `cgminer_manager run`.** `Server#build_puma_launcher` constructs its own `Puma::Configuration` inline. The file is there for direct `puma` / `rackup` invocations (dev harness, `config.ru`-based runs). Don't edit `config/puma.rb` expecting it to affect `run`.
+
+11. **Out-of-band git changes are normal.** Don't treat surprising git state (uncommitted changes you didn't make, an unfamiliar branch) as a tool malfunction — the maintainer works outside the assistant session.
+
+## Release process
+
+<!-- metadata: release, publishing -->
+
+Not automated. On a clean `master`:
+
+```sh
+bundle exec rake                                     # must pass clean
+# bump VERSION in lib/cgminer_manager/version.rb
+# update CHANGELOG.md (Keep-a-Changelog format)
+git commit -am "Release vX.Y.Z"
+gem build cgminer_manager.gemspec                    # produces cgminer_manager-X.Y.Z.gem
+gem push cgminer_manager-X.Y.Z.gem                   # requires 2FA (rubygems_mfa_required=true)
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+Docker image is not currently pushed by CI.
+
+## Where to look for deeper context
+
+<!-- metadata: doc-navigation -->
+
+| Question | File |
+|---|---|
+| How do the classes relate architecturally? Why two upstreams? Why the signal dance? | [`docs/architecture.md`](docs/architecture.md) |
+| What does each class do? | [`docs/components.md`](docs/components.md) |
+| What's the route/CLI/env contract? What's in the structured log? | [`docs/interfaces.md`](docs/interfaces.md) |
+| What's in a `ViewMiner` / `FleetWriteResult`? What errors can be raised? | [`docs/data_models.md`](docs/data_models.md) |
+| How does a request flow? How does admin fan-out work? Release process? | [`docs/workflows.md`](docs/workflows.md) |
+| Runtime deps? Why Ruby 3.2+? Why no Rails? | [`docs/dependencies.md`](docs/dependencies.md) |
+| Known doc/code drift, unwired knobs, cleanup recommendations | [`docs/review_notes.md`](docs/review_notes.md) |
+| Full knowledge-base index | [`docs/index.md`](docs/index.md) |
+| User-facing docs | [`README.md`](README.md) |
+| Release history, 1.0 rewrite, 1.1 UI restoration, 1.2 admin restoration | [`CHANGELOG.md`](CHANGELOG.md) |
+| 0.x Rails → 1.0 Sinatra upgrade guide | [`MIGRATION.md`](MIGRATION.md) |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ All settings come from environment variables.
 - `bin/cgminer_manager doctor` — verify `miners.yml`, cgminer reachability, and monitor `/v2/miners`.
 - `bin/cgminer_manager version` — print version.
 
+### Errors and Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean shutdown (`run`), all checks passed (`doctor`), or normal completion (`version`). |
+| `1` | `doctor`: at least one check failed. |
+| `2` | Configuration error (missing `CGMINER_MONITOR_URL`, unreadable `miners.yml`, invalid `LOG_FORMAT`/`LOG_LEVEL`, etc.). |
+| `64` | Unknown or missing CLI verb (`EX_USAGE`-ish). |
+
+The gem's error taxonomy (all under `CgminerManager::Error < StandardError`):
+
+-   `CgminerManager::ConfigError` — configuration validation failed at boot. The CLI translates this to exit 2.
+-   `CgminerManager::MonitorError::ConnectionError` — couldn't reach `cgminer_monitor` (DNS, refused, timeout). Renders a "data source unavailable" banner on the dashboard; fails `doctor`.
+-   `CgminerManager::MonitorError::ApiError` — monitor answered with a non-2xx response. Carries `status:` and `body:`. Same UI behavior as `ConnectionError`.
+-   `CgminerManager::PoolManagerError::DidNotConverge` — a pool operation's post-write verification query saw an unexpected state. Caught internally and surfaced as `:indeterminate` in the per-miner result row (not raised to the caller).
+
 ## HTTP surface
 
 - `GET /` — dashboard (Summary / Miner Pool / Admin tabs).
@@ -130,6 +146,14 @@ The typed admin button list (`version`/`stats`/`devs`/`zero`/`save`/`restart`/`q
 3. Per-command audit logging (`admin.command`, `admin.raw_command`, `admin.result`, `admin.auth_failed`, `admin.scope_rejected`) with a `request_id` UUID threading entry and exit events for any given POST.
 
 Strongly recommend setting `CGMINER_MANAGER_ADMIN_USER` and `CGMINER_MANAGER_ADMIN_PASSWORD` in any deployment where the UI is reachable beyond localhost. Basic Auth transmits credentials base64-encoded (reversible), so also terminate TLS at a reverse proxy in that case.
+
+## Further Reading
+
+-   [`CHANGELOG.md`](CHANGELOG.md) — release history: 1.0 Sinatra rewrite, 1.1 rich UI restoration, 1.2 admin surface restoration.
+-   [`MIGRATION.md`](MIGRATION.md) — step-by-step upgrade from the 0.x Rails engine era.
+-   [`AGENTS.md`](AGENTS.md) — context for AI coding assistants; also a useful conventions-and-extension guide for human contributors.
+-   [`docs/`](docs/) — topic-split deep dives on architecture, components, interfaces, data models, workflows, and dependencies. Start with [`docs/index.md`](docs/index.md).
+-   [`cgminer_monitor`](https://github.com/jramos/cgminer_monitor) and [`cgminer_api_client`](https://github.com/jramos/cgminer_api_client) — the upstream gems this service consumes. Operators frequently need to cross-reference them.
 
 ## Donating
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,248 @@
+# Architecture
+
+## Design goals
+
+1. **One process, foreground, supervisor-driven.** No daemonize, no PID file, no `start`/`stop`/`restart` subcommands — only `run`. systemd / docker / launchd owns the lifecycle.
+2. **Separation between read path and write path.** Read-path queries (dashboard, graphs, per-miner snapshots) all go through `cgminer_monitor` over HTTP. Write-path operations (pool management, admin RPC) go direct to cgminer instances over TCP via `cgminer_api_client`. Neither path shares connection state with the other.
+3. **Thread-capped parallel fan-out.** A dashboard render with 10 miners fires 4 monitor requests per miner = 40 requests; a pool operation across 10 miners fires 10 TCP RPCs plus a save per miner = 20. Both paths bound concurrency via a `Queue + Mutex` worker pool to avoid thundering herds against upstream services (default 8 threads, tunable via `POOL_THREAD_CAP`).
+4. **Structural error recovery for reads, explicit confirmation for writes.** A monitor tile that 5xx's renders "data source unavailable" banner without failing the whole dashboard. A pool operation returns a per-miner result envelope (`:ok`/`:failed`/`:indeterminate`) so the operator can see exactly what happened to each miner.
+5. **`Config` is immutable at boot.** `Data.define`, validated once. Changing anything requires a restart. (One exception: the `AdminAuth` middleware reads its env vars per-request — see below.)
+6. **Admin surface is defensive in depth.** CSRF + optional Basic Auth + scope restrictions + audit logging. Anyone who reaches `/manager/admin/run` can run any cgminer verb — the allowlist is *ergonomic* UI copy, not a security boundary.
+
+## The single-thread HTTP execution model
+
+```mermaid
+sequenceDiagram
+    participant Main as Main thread
+    participant Queue as @stop: Queue
+    participant Puma as Puma thread
+    participant HTTP as Client HTTP reqs
+    participant App as HttpApp
+
+    Main->>Main: install_signal_handlers (SIGTERM/SIGINT → @stop)
+    Main->>Main: configure_http_app (set class attrs on HttpApp)
+    Main->>Main: Logger.info 'server.start'
+
+    Main->>Main: @booted = Queue.new
+    Main->>Main: build Puma::Launcher
+    Main->>Puma: Thread.new { launcher.run }
+    Puma->>Puma: setup_signals (overwrites our SIGTERM handler!)
+    Puma->>Puma: bind listener, setup workers
+    Puma->>Main: @booted << true (launcher.events.on_booted)
+
+    Main->>Main: @booted.pop (block until Puma boot)
+    Main->>Main: install_signal_handlers again (reclaim SIGTERM)
+
+    loop
+        HTTP->>Puma: request
+        Puma->>App: Rack::Builder dispatch
+        App-->>Puma: response
+        Puma-->>HTTP: response
+    end
+
+    Main->>Queue: @stop.pop (blocks)
+    Note over Main: SIGTERM arrives
+    Main->>Queue: signal pushed to @stop
+    Queue-->>Main: pop returns 'TERM'
+    Main->>Puma: launcher.stop
+    Puma-->>Main: thread exits
+    Main->>Main: puma_thread.join(shutdown_timeout)
+    Main->>Main: exit 0
+```
+
+**Why the two-step signal-handler install is subtle.** `Puma::Launcher#run` calls `setup_signals` synchronously inside the Puma thread, which blows away any SIGTERM/SIGINT handlers the main thread installed. So the dance is:
+
+1. Main thread installs handlers (so a SIGTERM before Puma boot doesn't leave us in an inconsistent state).
+2. Puma thread runs `setup_signals` (overwrites with Puma's).
+3. `launcher.events.on_booted { booted << true }` fires when the listener is bound.
+4. Main thread waits on `@booted.pop`.
+5. Main thread re-installs handlers (Puma's are now replaced with ours).
+
+Plus `raise_exception_on_sigterm false` — without it, Puma raises `SignalException` on SIGTERM inside its thread, bypassing our `@stop` queue entirely.
+
+If you change how `Server` starts or stops Puma, re-verify that SIGTERM reliably routes through `@stop`.
+
+## Request lifecycle (dashboard read)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Puma
+    participant CSRF as ConditionalAuthenticityToken
+    participant App as HttpApp
+    participant Thread as snapshot worker
+    participant Monitor as cgminer_monitor
+    participant Adapter as SnapshotAdapter
+    participant HAML
+
+    Client->>Puma: GET /
+    Puma->>CSRF: middleware chain
+    CSRF-->>App: pass-through (GET, no token needed)
+    App->>App: build_dashboard_view_model
+    App->>Monitor: GET /v2/miners
+    Monitor-->>App: {miners: [...]}
+    App->>App: fetch_snapshots_for(miners) — spawn worker pool
+
+    par per-miner parallel
+        App->>Thread: spawn with @stop queue
+        Thread->>Monitor: GET /v2/miners/:id/summary
+        Thread->>Monitor: GET /v2/miners/:id/devices
+        Thread->>Monitor: GET /v2/miners/:id/pools
+        Thread->>Monitor: GET /v2/miners/:id/stats
+        Monitor-->>Thread: four responses (each may fail independently)
+        Thread->>Thread: safe_fetch wraps each in {error: msg} on rescue
+    end
+
+    App->>Adapter: SnapshotAdapter.build_miner_data(configured_miners, snapshots)
+    Adapter->>Adapter: per-type legacy shape: [{type => sanitize(response[inner_key])}]
+    Adapter-->>App: @miner_data
+    App->>App: build_view_miner_pool(monitor_miners) → ViewMiner instances
+    App->>HAML: haml :'manager/index' with @miner_pool, @miner_data, @bad_chain_elements
+    HAML-->>App: HTML
+    App-->>Puma: 200 HTML
+    Puma-->>Client: response
+```
+
+**Key observations on the read path:**
+
+- Each tile is fetched independently. If `monitor.pools(miner)` 5xxs but `monitor.summary(miner)` succeeds, the miner's row on the dashboard still renders — just with the Pools tab empty.
+- `build_dashboard_view_model` rescues `MonitorError` *once at the top level*: if `monitor.miners` itself fails (can't even enumerate miners), we fall back to `miners.yml` as the list and set `banner: "data source unavailable"`.
+- Snapshots are cached inside a single request via `Thread.new { ... fetch_tile ... }`; no request-to-request caching.
+- The legacy HAML partials (pre-dating the 1.1 restoration) read the shape `@miner_data[i][:summary].first[:summary]` — nested-array-of-arrays with a type-keyed inner hash. That's why `SnapshotAdapter` exists: the monitor's `/v2/miners/:id/summary` envelope is `{miner:, command:, fetched_at:, ok:, response: {STATUS: [...], SUMMARY: [...]}, error:}`, but the partials expect `[{summary: [...]}]`. The adapter bridges that.
+
+## Request lifecycle (admin write, raw RPC)
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Puma
+    participant AA as AdminAuth
+    participant CSRF as ConditionalAuthenticityToken
+    participant App as HttpApp
+    participant Cmdr as CgminerCommander
+    participant Miners as cgminer instances
+
+    Browser->>Puma: POST /manager/admin/run<br/>command=pools args= scope=all
+    Puma->>AA: middleware chain
+    AA->>AA: path matches /(manager|miner/.../admin)/
+
+    alt Basic Auth configured AND valid
+        AA->>AA: env['cgminer_manager.admin_authed'] = true
+    else Basic Auth configured but invalid
+        AA->>AA: Logger.warn 'admin.auth_failed'
+        AA-->>Browser: 401 + WWW-Authenticate
+    else Basic Auth not configured
+        AA-->>CSRF: pass through (admin_authed = false)
+    end
+
+    CSRF->>CSRF: admin_authed? → skip token check : validate token
+    CSRF-->>App: dispatch
+
+    App->>App: validate command (ADMIN_RAW_COMMAND_PATTERN)
+    App->>App: scope check (reject hardware-tuning + scope=all)
+    App->>App: Logger.info 'admin.raw_command' (entry event)
+    App->>Cmdr: raw!(command: ..., args: ...)
+
+    par each miner
+        Cmdr->>Miners: Miner.query(verb, *args)
+        Miners-->>Cmdr: response or raise
+        Cmdr->>Cmdr: wrap in FleetWriteEntry (ok/failed)
+    end
+
+    Cmdr-->>App: FleetWriteResult
+    App->>App: Logger.info 'admin.result' (exit event, same request_id)
+    App->>App: render_partial 'shared/fleet_write'
+    App-->>Puma: 200 HTML
+    Puma-->>Browser: response
+```
+
+**Key observations on the write path:**
+
+- Every admin POST gets a `request_id = SecureRandom.uuid` in the `before` filter. That ID threads through the entry event (`admin.command` or `admin.raw_command`), any rejection events (`admin.scope_rejected`, `admin.auth_failed`), and the exit event (`admin.result`). Grep the structured log by `request_id` to see the full story for one operation.
+- `ADMIN_RAW_COMMAND_PATTERN = /\A[a-z][a-z0-9_+]*\z/` is the regex applied to the `command` param before anything else. No whitespace, no null bytes, no path traversal — but still permits every real cgminer verb.
+- `SCOPE_RESTRICTED_VERBS` (`pgaset`/`ascset`/`pgarestart`/`ascrestart`/`pga{enable,disable}`/`asc{enable,disable}`) refuse `scope=all` with 422 + `admin.scope_rejected` log. The UI also disables the "all" option in the scope dropdown when the command input matches one of these, but the server-side check is the defensive layer.
+- `args` is split on `,` before hitting `cgminer_api_client`'s own escape logic. That means commas inside argument values are not escapable through the form. Noted in the README.
+
+## Request lifecycle (pool management)
+
+Same shape as admin, but:
+
+- Entry point is `POST /manager/manage_pools` or `POST /miner/:miner_id/manage_pools` with `action_name` ∈ `{enable, disable, remove, add}` and `pool_index` or `url/user/pass` params.
+- No Basic Auth gate on pool routes — CSRF alone.
+- Backed by `PoolManager` (not `CgminerCommander`).
+- `PoolManager` runs the requested action, then verifies state (queries pools, checks the status matches expected) for `enable`/`disable`/`remove`. `add` is unverified (cgminer's `addpool` doesn't return the new index deterministically).
+- Per-miner result has both `command_status` and `save_status` — because pool changes aren't persistent unless `save` is called. `save_status: :skipped` on failed commands.
+
+## Graceful shutdown
+
+```mermaid
+flowchart TD
+    A[Signal or Puma crash] --> B[push to @stop Queue]
+    B --> C[Main thread unblocks from @stop.pop]
+    C --> D[Logger.info 'server.stopping']
+    D --> E[launcher.stop]
+    E --> F[puma_thread.join with shutdown_timeout]
+    F -->|clean| G[Logger.info 'server.stopped']
+    F -.timeout.- G
+    G --> H[Server#run returns 0]
+    H --> I[CLI exit 0]
+
+    X[Unhandled StandardError in Server#run body] -.- Y[not caught]
+    Y --> Z[CLI#run rescues ConfigError only]
+    Z --> ZZ[other StandardError propagates; CLI exits non-zero from Ruby]
+```
+
+`CLI#run` only rescues `ConfigError` (mapped to exit 2). Other errors that escape `Server#run` propagate as unhandled Ruby exceptions — the process dies and the supervisor restarts it. This is intentional: we don't want to silently paper over bugs in production.
+
+## Design patterns
+
+### Config as `Data.define`
+`Config` is a 14-field immutable value object built from `ENV` via `Config.from_env`, validated in `validate!`, never mutated at runtime. No `attr_accessor`, no `reload!`. Same pattern as `cgminer_monitor`.
+
+### Structured logging, stdout only
+`Logger` is a module singleton with `info`/`warn`/`error`/`debug` class methods taking keyword args. Every event has an `event:` key for grep-ability. Writes JSON (default) or text via `$stdout`, thread-safe via `Mutex`. No `warn`/`puts`/`$stderr` calls anywhere in `lib/` — the CLI only writes to `$stderr` for its own config errors and usage hints.
+
+### Queue-driven shutdown
+A shared `@stop: Queue` is the rendezvous point for "time to stop." Signal handlers push to it; Puma thread crashes push to it (`@stop << 'puma_crash'`); main thread blocks on it. Same pattern as `cgminer_monitor`.
+
+### Class-level state on `HttpApp`
+Sinatra routes are class-level blocks; passing per-request context from the orchestrator is awkward. The compromise: `Server#configure_http_app` sets `HttpApp.monitor_url`, `.miners_file`, `.stale_threshold_seconds`, `.pool_thread_cap` before spawning Puma. Tests use `HttpApp.configure_for_test!(...)` or call `HttpApp.reset_configured_miners!` between examples.
+
+### Thread-capped fan-out (two places)
+Both `CgminerCommander` and `PoolManager` use the same pattern: a `Queue` pre-loaded with all miners, a fixed number of worker threads (min of `thread_cap` and `miners.size`), each popping with `queue.pop(true)` and writing to a shared `results` array under a `Mutex`. When the queue is drained, `queue.pop(true)` raises `ThreadError` and the worker breaks out of its loop.
+
+Also appears in `HttpApp#fetch_snapshots_for` (different shape: tile-per-miner-hash instead of a result array).
+
+### `SnapshotAdapter` as a shape-translation leaf
+One module, four methods. Turns monitor's `/v2/miners/:id/:type` envelope into the `[{type => data}]` shape that legacy partials read. Key sanitization (`"MHS 5s"` → `:mhs_5s`, `"Device Hardware%"` → `:'device_hardware%'`) matches `cgminer_api_client::Miner#sanitized` — **not** cgminer_monitor's Poller normalization (which maps `%` to `_pct`; that rule only applies to time-series sample metadata). The adapter is a compatibility layer, not a general-purpose JSON transformer.
+
+### `ConditionalAuthenticityToken`
+Subclass of `Rack::Protection::AuthenticityToken` that short-circuits to `@app.call(env)` if `env['cgminer_manager.admin_authed']` is set. `AdminAuth` sets that flag when Basic Auth validates. The rationale: a valid static Basic Auth credential is strictly stronger proof than a session cookie + CSRF token, and this lets operators `curl` admin routes during incidents without scraping a CSRF token first.
+
+### Ergonomic-vs-defensive distinction for admin verbs
+The `ALLOWED_ADMIN_QUERIES` / `ALLOWED_ADMIN_WRITES` allowlists are *UI copy* for the one-click buttons — not a security boundary. Anyone who can reach `/manager/admin/run` can issue any cgminer verb. The real defensive layers are:
+1. HTTP Basic Auth (via `CGMINER_MANAGER_ADMIN_USER`/`_PASSWORD`).
+2. `SCOPE_RESTRICTED_VERBS` server-side rejection of `scope=all` for hardware-tuning commands.
+3. `ADMIN_RAW_COMMAND_PATTERN` regex.
+4. Audit logging per request with `request_id` threading.
+
+If you add a new "dangerous" admin verb, add it to `SCOPE_RESTRICTED_VERBS` — don't just trust the UI to disable `scope=all`.
+
+### `ViewMiner` / `ViewMinerPool` value types for HAML partials
+Legacy partials expected to receive `CgminerApiClient::Miner` instances with `.host`, `.port`, `.available?`, `.to_s`. Now the data comes from monitor's `/v2/miners` response. `ViewMiner` is a `Data.define` with the same public surface, built from the monitor data via `ViewMiner.build(host, port, available, label)`. Value-equality matters because `_warnings.haml` does `@bad_chain_elements.uniq!` — `Data.define` gives this for free.
+
+## Admin audit log schema
+
+All admin POSTs emit (at minimum) one entry event and one exit event, threaded by `request_id`:
+
+| Event | When | Fields |
+|---|---|---|
+| `admin.command` | on typed-allowlist POST | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope` |
+| `admin.raw_command` | on `/admin/run` POST | same as above + `args` |
+| `admin.result` | after the commander returns | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `elapsed_ms` |
+| `admin.scope_rejected` | 422 from scope check | `request_id`, `command`, `scope` |
+| `admin.auth_failed` | 401 from `AdminAuth` | `reason` (`missing_creds`/`bad_creds`/`user_mismatch`), `path`, `remote_ip`, `user_agent` |
+
+`session_id_hash` is a 12-char SHA256 prefix of the session ID — stable enough to correlate across requests, short enough to not leak the full session ID into logs.
+
+Grep `request_id=<uuid>` to get the full story of one operation.

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -1,0 +1,191 @@
+# Codebase Info
+
+## What this is
+
+`cgminer_manager` is a **Sinatra web UI** for operating cgminer mining rigs. It ships as a gem (`gem install cgminer_manager`) with a single executable (`cgminer_manager`) that runs a self-hosted Puma server serving a dashboard (`/`), per-miner pages (`/miner/:id`), pool-management forms, and a locked-down admin surface. Screenshots in `public/screenshots/` show the rendered pages.
+
+It is **not** a library — nobody `require`s it from their own code. It is invoked through its CLI only.
+
+It sits at the **top** of the three-gem chain:
+
+- `cgminer_api_client` (TCP client for cgminer's JSON API) — used directly for write-path operations (pool management, admin RPC).
+- `cgminer_monitor` (daemon that polls cgminer and exposes HTTP + MongoDB-backed metrics) — used for the read path (dashboard, graphs, per-miner snapshots).
+- `cgminer_manager` (this repo) — orchestrates the UI on top of both.
+
+The 1.0 rewrite (April 2026) moved this from a Rails 4.2 engine to a standalone Sinatra service. The 1.1 release restored the rich dashboard / per-miner UI on top of the new architecture. The 1.2 release restored (and hardened) the admin surface.
+
+## Stack
+
+- **Language:** Ruby 3.2+ (gemspec floor). `.ruby-version` pins to 4.0.2 for local dev.
+- **CI matrix:** Ruby 3.2 / 3.3 / 3.4 required. Nightly best-effort job (see `.github/workflows/nightly.yml`) tests Ruby 4.0 / head.
+- **Web framework:** Sinatra 4.0 + `sinatra-contrib` (for `content_for`).
+- **HTTP server:** Puma 6.4, single-process, 1–8 threads, embedded via `Puma::Launcher`.
+- **Template engine:** HAML 6.
+- **HTTP client (upstream):** `http` gem 5.2 (not Faraday, not Net::HTTP).
+- **Security middleware:** `rack-protection` 4.0 (CSRF), with a subclassed `ConditionalAuthenticityToken` that skips for Basic-Auth-authenticated admin requests.
+- **Session:** `Rack::Session::Cookie`, signed with `SESSION_SECRET`.
+- **Runtime gem deps:** `cgminer_api_client ~> 0.3`, `sinatra ~> 4.0`, `sinatra-contrib ~> 4.0`, `puma ~> 6.4`, `haml ~> 6.3`, `http ~> 5.2`, `rack-protection ~> 4.0`. No MongoDB, no database.
+- **Dev deps:** `rspec`, `webmock`, `rack-test`, `rubocop` (+ `-rake`, `-rspec`), `rake`, `simplecov`. Plus a pinned `parallel < 2.0` so Ruby 3.2 can still bundle (transitive dep of rubocop).
+- **Test framework:** RSpec. Unit specs at `spec/cgminer_manager/**`, integration specs at `spec/integration/**` (tagged `:integration`). WebMock + a real TCP FakeCgminer for end-to-end.
+- **Lint:** RuboCop with `TargetRubyVersion: 3.2`. `Metrics/ClassLength` raised to 550 to accommodate `HttpApp`. Default rake task runs `[rubocop, spec]`.
+- **Containerization:** multi-stage Dockerfile (`ruby:3.4-slim` base) and `docker-compose.yml` bundling manager + cgminer_monitor + Mongo.
+
+## Directory layout
+
+```
+cgminer_manager/
+├── bin/
+│   └── cgminer_manager              # CLI entrypoint: delegates to CgminerManager::CLI.run(ARGV)
+├── lib/
+│   ├── cgminer_manager.rb           # require graph only
+│   └── cgminer_manager/
+│       ├── admin_auth.rb            # AdminAuth middleware + ConditionalAuthenticityToken
+│       ├── cgminer_commander.rb     # Thread-cap fan-out for fleet admin RPC (reads + writes)
+│       ├── cli.rb                   # CLI dispatch: run / doctor / version + exit codes
+│       ├── config.rb                # Data.define Config, from_env, validate!
+│       ├── errors.rb                # Error, ConfigError, MonitorError {Connection, Api}, PoolManagerError
+│       ├── fleet_query_result.rb    # FleetQueryEntry + FleetQueryResult (Data.define)
+│       ├── fleet_write_result.rb    # FleetWriteEntry + FleetWriteResult (Data.define)
+│       ├── http_app.rb              # Sinatra app: 14 routes, helpers, view-model builders (~700 LOC)
+│       ├── logger.rb                # Structured JSON/text logger (module singleton, thread-safe)
+│       ├── monitor_client.rb        # HTTP client for cgminer_monitor /v2/*
+│       ├── pool_manager.rb          # PoolManager + MinerEntry + PoolActionResult (Data.define)
+│       ├── server.rb                # Orchestrator: signals, Puma launcher, shutdown
+│       ├── snapshot_adapter.rb      # Monitor /v2/* envelope → legacy HAML shape translator
+│       ├── version.rb               # VERSION = "1.2.0"
+│       └── view_miner.rb            # ViewMiner + ViewMinerPool (Data.define value types for partials)
+├── views/                           # HAML templates (NOT packaged? yes — gemspec includes views/**/*)
+│   ├── layout.haml
+│   ├── _header.haml, _footer.haml
+│   ├── manager/ (_summary, _miner_pool, _admin, index)
+│   ├── miner/ (_summary, _devices, _pools, _stats, _admin, show)
+│   ├── shared/ (_fleet_query, _fleet_write, _manage_pools, _miner_devices_table,
+│   │            _miner_hashrate_table, _warnings, graphs/{_hashrate, _temperature,
+│   │            _hardware_error, _device_rejected, _pool_rejected, _pool_stale,
+│   │            _availability})
+│   └── errors/ (404, 500)
+├── public/                          # Static assets served by Puma (packaged)
+│   ├── 404.html, 422.html, 500.html  # Rack-level fallbacks
+│   ├── audio/warning.mp3
+│   └── robots.txt
+│   (css/, js/, screenshots/, fonts/ are present on-disk but excluded from this tree
+│    listing — they're the Chart.js assets, stylesheet bundle, and release screenshots)
+├── config/
+│   ├── miners.yml.example           # [{ host, port, [label] }]
+│   ├── puma.rb                      # Puma config (not used by `run`; Server#build_puma_launcher
+│   │                                 # constructs its own. Kept for `rackup` / `puma` direct invocations.)
+├── config.ru                        # Rack entrypoint — mirrors build_puma_launcher without signals/shutdown
+├── spec/
+│   ├── spec_helper.rb               # SimpleCov + WebMock + load support/**
+│   ├── cgminer_manager/             # Unit specs (11 files, one per lib/)
+│   ├── integration/                 # 13 HTTP-level specs tagged :integration
+│   ├── fixtures/monitor/*.json      # Canned monitor /v2/* responses
+│   └── support/
+│       ├── cgminer_fixtures.rb      # Shared with cgminer_api_client and monitor
+│       ├── fake_cgminer.rb          # Shared in-process TCP server for integration specs
+│       └── monitor_stubs.rb         # WebMock helpers that stub monitor's /v2/*
+├── dev/
+│   └── screenshots/                 # Scripted harness for regenerating public/screenshots/*.png
+│       ├── fake_cgminer_fleet.rb    # Launches 6 TCP listeners on 127.0.0.1:40281-40286
+│       ├── fake_monitor.rb          # Stand-in monitor process for the harness
+│       ├── scenario.rb              # Drives Playwright through the UI and captures pages
+│       ├── boot.sh, teardown.sh
+│       └── miners.yml
+├── .github/workflows/
+│   ├── ci.yml                       # lint + test matrix + integration jobs
+│   └── nightly.yml                  # Ruby 4.0 / head experimental runs
+├── .rubocop.yml
+├── .rspec
+├── .ruby-version                    # 4.0.2 (local dev; gemspec allows 3.2+)
+├── Rakefile                         # default: [rubocop, spec]; plus spec:refresh_monitor_fixtures
+├── Gemfile
+├── cgminer_manager.gemspec
+├── docker-compose.yml               # manager + monitor + mongo
+├── Dockerfile                       # multi-stage, ruby:3.4-slim base
+├── CHANGELOG.md                     # Keep-a-Changelog; 1.2.0 → 1.0.0 entries
+├── MIGRATION.md                     # 0.x Rails → 1.0 Sinatra upgrade guide
+├── README.md
+└── LICENSE.txt                      # MIT
+```
+
+**What's packaged in the gem** (via the gemspec `spec.files` glob): `lib/**/*`, `views/**/*`, `public/**/*`, `bin/*`, `config/*.example`, `config/puma.rb`, `config.ru`, README, MIGRATION, CHANGELOG, LICENSE. Notably **not** packaged: `spec/`, `dev/`, `.github/`, `Dockerfile`, `docker-compose.yml`, `docs/`.
+
+## Languages and tooling
+
+| | |
+|---|---|
+| Primary language | Ruby |
+| Templating | HAML 6 |
+| Static assets | Plain CSS + JS (Chart.js), served from `public/` — no asset pipeline, no bundler |
+| Build tool | `bundler`, `rake` (default task), `docker` |
+| Package format | RubyGem (`.gem`) + Docker image |
+| Distribution | RubyGems.org; Docker image not yet pushed to a registry |
+
+## High-level module graph
+
+```mermaid
+graph TB
+    CLI[bin/cgminer_manager<br/>CgminerManager::CLI]
+    Config[Config]
+    Server[Server<br/>Puma orchestrator]
+    Puma[Puma::Launcher]
+    AdminAuth[AdminAuth middleware]
+    CSRF[ConditionalAuthenticityToken]
+    HttpApp[HttpApp<br/>Sinatra::Base]
+    HAML[HAML views]
+    Logger[Logger module singleton]
+    MonClient[MonitorClient]
+    Monitor[/cgminer_monitor<br/>HTTP :9292/]
+    Commander[CgminerCommander]
+    PoolMgr[PoolManager]
+    APIClient[CgminerApiClient::Miner]
+    Cgminer[/cgminer instances<br/>TCP :4028/]
+    Adapter[SnapshotAdapter]
+    ViewMiner[ViewMiner + ViewMinerPool]
+
+    CLI -->|run| Server
+    CLI -->|doctor| MonClient
+    CLI -->|doctor| APIClient
+
+    Server -->|build + start| Puma
+    Server -.class-attrs.-> HttpApp
+    Puma -->|Rack::Builder| HttpApp
+
+    HttpApp -.use.-> AdminAuth
+    HttpApp -.use.-> CSRF
+    HttpApp -->|renders| HAML
+    HttpApp -->|reads via| MonClient
+    MonClient -->|HTTP GET| Monitor
+
+    HttpApp -->|admin POSTs| Commander
+    HttpApp -->|pool POSTs| PoolMgr
+    Commander -->|parallel fan-out| APIClient
+    PoolMgr -->|parallel fan-out| APIClient
+    APIClient -->|TCP| Cgminer
+
+    HttpApp -->|reshape for| Adapter
+    HttpApp -->|build| ViewMiner
+
+    HttpApp -.logs.-> Logger
+    Server -.logs.-> Logger
+    MonClient -.logs.-> Logger
+    AdminAuth -.logs.-> Logger
+```
+
+## Key facts worth knowing up front
+
+1. **Two upstreams: HTTP to monitor, TCP to cgminer.** Read path goes through `MonitorClient` (HTTP). Write path goes direct to cgminer via `cgminer_api_client` (TCP). The manager never writes to Mongo and never reads cgminer directly for UI tiles.
+2. **Single-process, foreground, supervisor-driven.** No background workers. No daemonize. `cgminer_monitor run` (the CLI verb here is just `cgminer_manager run`) blocks until SIGTERM/SIGINT, then exits 0.
+3. **`Config` is immutable** (`Data.define`). Validated once at boot. No hot reload. Exception: `AdminAuth` reads `CGMINER_MANAGER_ADMIN_USER` / `CGMINER_MANAGER_ADMIN_PASSWORD` per-request (intentional — lets dev harnesses toggle auth without restart).
+4. **`HttpApp` has class-level state** set by `Server#configure_http_app` at boot: `.monitor_url`, `.miners_file`, `.stale_threshold_seconds`, `.pool_thread_cap`, plus a memoized `.configured_miners` cache. Tests must call `HttpApp.reset_configured_miners!` (or `HttpApp.configure_for_test!`) between examples.
+5. **CgminerCommander + PoolManager both use thread-cap fan-out** via `Queue` + `Mutex`. Default cap is 8. Configurable via `POOL_THREAD_CAP`. Scoped to the request lifecycle; no persistent thread pool.
+6. **`CgminerApiClient::Miner.to_s` is monkey-patched** in `http_app.rb` to return `"host:port"` so result rows display a stable identifier. Upstream's `Miner` doesn't define `to_s`; `respond_to_missing?` excludes `to_*`, so this is safe.
+7. **Admin surface has three defensive layers.** In order: (1) CSRF for browser path, (2) optional HTTP Basic Auth when both `CGMINER_MANAGER_ADMIN_USER` and `CGMINER_MANAGER_ADMIN_PASSWORD` are set — valid Basic Auth bypasses CSRF, (3) scope restrictions on hardware-tuning verbs (`pgaset`/`ascset`/etc. refuse `scope=all`). Plus per-request audit logging threaded by `request_id`.
+8. **No OpenAPI spec.** Unlike `cgminer_monitor`, the HTTP surface here is not documented as an OpenAPI document. Routes are defined only in `http_app.rb`. If you add one, add the corresponding CI parity check too.
+
+## Version and release posture
+
+- Current release: **1.2.0** (2026-04-17). See `CHANGELOG.md` for the 1.0 / 1.1 / 1.2 release notes.
+- Semantic Versioning. 1.0 drew a line under the 0.x Rails-engine era. `v0-legacy` tag preserves the final Rails commit for rollback.
+- `rubygems_mfa_required` is set in gemspec metadata.
+- `Gemfile.lock` is `.gitignore`d — this gem expects consumers to generate their own.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,304 @@
+# Components
+
+Every major component lives in a single file under `lib/cgminer_manager/`. No service registry, no dependency injection container. Components are plain Ruby classes, modules, or `Data.define` value objects composed directly.
+
+## Component map
+
+```mermaid
+graph LR
+    subgraph cli_rb["cli.rb"]
+        CLI[CLI]
+    end
+    subgraph server_rb["server.rb"]
+        Srv[Server]
+    end
+    subgraph http_app_rb["http_app.rb"]
+        App[HttpApp]
+    end
+    subgraph config_rb["config.rb"]
+        Cfg[Config]
+    end
+    subgraph errors_rb["errors.rb"]
+        Err[Error hierarchy]
+    end
+    subgraph logger_rb["logger.rb"]
+        Log[Logger]
+    end
+    subgraph monitor_client_rb["monitor_client.rb"]
+        MC[MonitorClient]
+    end
+    subgraph pool_manager_rb["pool_manager.rb"]
+        PM[PoolManager]
+    end
+    subgraph cgminer_commander_rb["cgminer_commander.rb"]
+        Cmd[CgminerCommander]
+    end
+    subgraph admin_auth_rb["admin_auth.rb"]
+        AA[AdminAuth + ConditionalAuthenticityToken]
+    end
+    subgraph snapshot_adapter_rb["snapshot_adapter.rb"]
+        SA[SnapshotAdapter]
+    end
+    subgraph view_miner_rb["view_miner.rb"]
+        VM[ViewMiner + ViewMinerPool]
+    end
+    subgraph fleet_query_result_rb["fleet_query_result.rb"]
+        FQ[FleetQueryEntry + FleetQueryResult]
+    end
+    subgraph fleet_write_result_rb["fleet_write_result.rb"]
+        FW[FleetWriteEntry + FleetWriteResult]
+    end
+
+    CLI -->|run| Srv
+    CLI -->|doctor| MC
+    CLI -.-> Cfg
+    Srv -->|spawns| App
+    Srv -.class-attrs.-> App
+    App -.use.-> AA
+    App -->|reads via| MC
+    App -->|admin writes| Cmd
+    App -->|pool writes| PM
+    App -->|reshape| SA
+    App -->|build| VM
+    Cmd -->|returns| FQ
+    Cmd -->|returns| FW
+    Cfg -->|raises| Err
+    MC -->|raises| Err
+    App -.logs.-> Log
+    Srv -.logs.-> Log
+    MC -.logs.-> Log
+    AA -.logs.-> Log
+```
+
+## Component list
+
+### `CgminerManager` (module)
+**File:** `lib/cgminer_manager.rb`
+
+Top-level namespace. The file is only `require_relative` statements for the other files, in dependency order. No code other than the requires.
+
+### `CgminerManager::Error` and siblings
+**File:** `lib/cgminer_manager/errors.rb`
+
+Error hierarchy:
+
+- `Error < StandardError` — base class. Catch to rescue anything gem-specific.
+- `ConfigError < Error` — bad env var, missing `miners.yml`, invalid log level/format. Mapped to CLI exit 2.
+- `MonitorError < Error` — base for errors talking to cgminer_monitor.
+  - `MonitorError::ConnectionError < MonitorError` — can't reach monitor (DNS, refused, timeout).
+  - `MonitorError::ApiError < MonitorError` — monitor answered with non-2xx. Carries `status:` and `body:` readers.
+- `PoolManagerError::DidNotConverge < Error` — a pool operation's verification step failed (the observed state didn't match the expected state after the write).
+
+### `CgminerManager::Config` (`Data.define`)
+**File:** `lib/cgminer_manager/config.rb`
+
+14-field immutable config built from ENV. Fields: `monitor_url`, `miners_file`, `port`, `bind`, `log_format`, `log_level`, `session_secret`, `stale_threshold_seconds`, `shutdown_timeout`, `monitor_timeout`, `pool_thread_cap`, `rack_env`.
+
+Public surface:
+- `Config.from_env(env = ENV)` — build and validate in one call. Raises `ConfigError` on bad values.
+- `#validate!` — asserts `monitor_url` present, `miners_file` exists on disk, `log_format ∈ {json, text}`, `log_level ∈ {debug, info, warn, error}`.
+- `#load_miners` — parses `miners_file` into `[[host, port], ...]`, defaulting port to 4028.
+- `#production?` — `rack_env == 'production'`.
+
+Env mapping defaults: `PORT` 3000, `BIND` 127.0.0.1, `LOG_FORMAT` 'text' in dev / 'json' in prod, `LOG_LEVEL` info, `STALE_THRESHOLD_SECONDS` 300, `SHUTDOWN_TIMEOUT` 10, `MONITOR_TIMEOUT_MS` 2000, `POOL_THREAD_CAP` 8.
+
+`SESSION_SECRET` resolution: env value if set, else raises in production, else a generated `SecureRandom.hex(32)` in dev with a stderr warning.
+
+### `CgminerManager::Logger` (module singleton)
+**File:** `lib/cgminer_manager/logger.rb`
+
+Same shape as cgminer_monitor's logger. Module-level `info`/`warn`/`error`/`debug` taking keyword args, automatic `ts` and `level` fields, JSON (default) or text output, thread-safe via `Mutex`. `$stdout` by default; overridable via `Logger.output=` for tests.
+
+### `CgminerManager::CLI`
+**File:** `lib/cgminer_manager/cli.rb`
+
+CLI dispatch. `CLI.run(argv)` is the bin-script entry point.
+
+Verbs:
+
+| Verb | Behavior | Exit code |
+|---|---|---|
+| `run` | `Config.from_env` → set `Logger.format`/`level` → `Server.new(config).run` | 0 on clean shutdown (forwarded from `Server#run`) |
+| `doctor` | `Config.from_env` → check monitor `/v2/miners` → check each miner is TCP-reachable → verify each `miners.yml` entry is also in monitor's list | 0 if all checks pass, 1 otherwise |
+| `version` | `puts CgminerManager::VERSION` | 0 |
+| anything else | prints `unknown verb:` to stderr + usage line | 64 |
+
+Top-level `rescue ConfigError` maps any `ConfigError` raised by `cmd_run` or `cmd_doctor` to exit 2 with a `config error: <msg>` line on stderr.
+
+### `CgminerManager::Server`
+**File:** `lib/cgminer_manager/server.rb`
+
+Orchestrator for `run`. Owns the signal-handler dance, the Puma launcher, and the `@stop` queue.
+
+Public surface: `Server.new(config)` and `#run` (returns exit code, always 0 in the happy path).
+
+Key moves in `#run`:
+1. `install_signal_handlers` (INT/TERM → `@stop << signal`).
+2. `configure_http_app` — set class-level attrs on `HttpApp`.
+3. Log `server.start`.
+4. Set up `@booted = Queue.new`, build Puma launcher with `raise_exception_on_sigterm(false)`, spawn Puma thread that calls `launcher.run` (and pushes `'puma_crash'` to `@stop` on exception).
+5. Wait for `@booted.pop` (set by `launcher.events.on_booted`).
+6. `install_signal_handlers` again (Puma's `setup_signals` has overwritten ours).
+7. `@stop.pop` — block until signal or crash.
+8. `launcher.stop`, `puma_thread.join(shutdown_timeout)`, log `server.stopped`, return 0.
+
+### `CgminerManager::HttpApp`
+**File:** `lib/cgminer_manager/http_app.rb` (~700 LOC)
+
+The Sinatra app. Inherits from `Sinatra::Base`, uses `Sinatra::ContentFor` helper. Pins `set :root` to the repo root so `public/` and `views/` resolve correctly (Sinatra's auto-detection would point at `lib/cgminer_manager/`).
+
+Class-level state set by `Server#configure_http_app` at boot:
+- `.monitor_url` — base URL of cgminer_monitor.
+- `.miners_file` — path to `miners.yml`.
+- `.stale_threshold_seconds`, `.pool_thread_cap` — tuning knobs.
+- `.configured_miners` (memoized, built on first access from `miners_file`; returns `[[host, port, label]]` tuples).
+- `.reset_configured_miners!` (test-only reset).
+- `.configure_for_test!(...)` (test convenience).
+
+Middleware stack (applied inside `configure do`):
+1. `Rack::Session::Cookie` signed with `SESSION_SECRET`, `same_site: :lax`.
+2. `CgminerManager::AdminAuth` — gates `/manager|/miner/*/admin/*` routes when Basic Auth is configured.
+3. `CgminerManager::ConditionalAuthenticityToken` — Rack::Protection CSRF with the admin-Basic-Auth bypass.
+
+14 routes — see [`interfaces.md`](interfaces.md) for the full contract.
+
+Error handlers:
+- `not_found` → renders `views/errors/404.haml`.
+- `error` → logs `http.500` with backtrace (first 10 lines), renders `views/errors/500.haml`.
+
+Lots of view helpers defined via `helpers do`: HTML escape, CSRF token, format_hashrate, number_with_delimiter, time_ago_in_words, staleness_badge, get_stats_for (mis-spelled Rails-era helpers preserved for compatibility with the legacy partials), plus URL builders (`miner_url`, `manager_admin_path`, etc.) and view-model builders (`build_dashboard_view_model`, `build_miner_view_model`, `build_view_miner_pool`, `build_pool_manager_for_all`, `build_commander_for_all`, etc.).
+
+**Class-eval monkey patch** at the top of the file: `CgminerApiClient::Miner.class_eval { def to_s = "#{host}:#{port}" }`. Makes `FleetWriteEntry.miner` and `PoolManager::MinerEntry.miner` (populated from `miner.to_s`) display stable "host:port" identifiers. Safe because upstream `Miner#respond_to_missing?` excludes `to_*` names, so adding `to_s` doesn't collide with `method_missing`.
+
+### `CgminerManager::MonitorClient`
+**File:** `lib/cgminer_manager/monitor_client.rb`
+
+HTTP client for cgminer_monitor's `/v2/*` API. Uses the `http` gem.
+
+Public surface:
+- `MonitorClient.new(base_url:, timeout_ms: 2000)`.
+- `#miners` — `GET /v2/miners`.
+- `#summary(id)`, `#devices(id)`, `#pools(id)`, `#stats(id)` — `GET /v2/miners/:id/<type>`. `id` is CGI-escaped.
+- `#graph_data(metric:, miner_id: nil, since: nil)` — `GET /v2/graph_data/:metric` with optional query params.
+- `#healthz` — `GET /v2/healthz`.
+
+All methods return the parsed JSON body with `symbolize_names: true` on success. On error:
+- `HTTP::ConnectionError`, `HTTP::TimeoutError`, `Errno::ECONNREFUSED` → rewrap as `MonitorError::ConnectionError` with "monitor unreachable: …" message.
+- Non-2xx HTTP response → `MonitorError::ApiError` with `status:` and `body:`.
+
+Every call logs `monitor.call` with url, status, and `duration_ms`. Failures log `monitor.call.failed` with error class + message.
+
+**Not currently wired:** `Config#monitor_timeout` exists but `HttpApp#monitor_client` constructs `MonitorClient.new(base_url:)` without passing a timeout, so `MonitorClient` uses its default `2000` ms. (Flagged in `review_notes.md`.)
+
+### `CgminerManager::CgminerCommander`
+**File:** `lib/cgminer_manager/cgminer_commander.rb`
+
+Parallel fan-out for fleet admin RPC. Used by `/manager/admin/*` and `/miner/:id/admin/*` routes.
+
+Public surface:
+- `CgminerCommander.new(miners:, thread_cap: 8)` — `miners` is `[CgminerApiClient::Miner, ...]`.
+- Read methods → `FleetQueryResult`: `#version`, `#stats`, `#devs`.
+- Write methods → `FleetWriteResult`: `#zero!`, `#save!`, `#restart!`, `#quit!`, `#raw!(command:, args: nil)`.
+
+`raw!` splits `args` on `,` and passes the positional array to `Miner#query`. Any `CgminerApiClient::{ConnectionError, TimeoutError, ApiError}` gets captured into the entry's `error:` field rather than re-raised, so one bad miner doesn't fail the whole fan-out.
+
+Private `fan_out` helper: same pattern as `PoolManager#run_each` — `Queue` pre-loaded with miners, fixed worker count (`min(thread_cap, miners.size)`), results written into a fixed-size array under a `Mutex`, workers exit their loop when `queue.pop(true)` raises `ThreadError`.
+
+### `CgminerManager::PoolManager`
+**File:** `lib/cgminer_manager/pool_manager.rb`
+
+Parallel fan-out for pool-management operations. Used by `/manager/manage_pools` and `/miner/:id/manage_pools` routes.
+
+Inner types (both `Data.define`):
+- `MinerEntry(:miner, :command_status, :command_reason, :save_status, :save_reason)` — `#ok?` returns true only when both statuses are `:ok`. `#failed?` is true if `command_status == :failed`.
+- `PoolActionResult(:entries)` — `#all_ok?`, `#any_failed?`, `#successful`, `#failed`, `#indeterminate`.
+
+Public methods (all return `PoolActionResult`):
+- `#disable_pool(pool_index:)`, `#enable_pool(pool_index:)`, `#remove_pool(pool_index:)` — **verified**. Runs the write, then queries pools to confirm the state matches expected (`'Alive'` / `'Disabled'` / absent). Raises `PoolManagerError::DidNotConverge` internally, captured as `:indeterminate` in the entry.
+- `#add_pool(url:, user:, pass:)` — **unverified**. cgminer's `addpool` response doesn't return the new index deterministically, so there's no practical verification.
+- `#save` — pure save with no write before it.
+
+`run_verified` vs `run_unverified` helpers handle the save-after-command dance. `save_status` is `:skipped` when the command failed (no point saving an unchanged state) or when the caller is `run_unverified`.
+
+### `CgminerManager::AdminAuth` and `ConditionalAuthenticityToken`
+**File:** `lib/cgminer_manager/admin_auth.rb`
+
+Two Rack middlewares.
+
+**`AdminAuth`:**
+- Path regex `%r{\A/(manager|miner/[^/]+)/admin(/|\z)}` — only runs for admin routes.
+- Reads `CGMINER_MANAGER_ADMIN_USER` / `CGMINER_MANAGER_ADMIN_PASSWORD` from ENV **per-request**. Empty strings = unset. (Deliberate: lets dev harnesses toggle without restart.)
+- If not configured (either var empty), passes through (CSRF-only).
+- If configured: requires valid Basic Auth. On success, sets `env['cgminer_manager.admin_authed'] = true` and `env['cgminer_manager.admin_user']`. On failure, responds 401 with `WWW-Authenticate` header and logs `admin.auth_failed` with `reason` ∈ `{missing_creds, bad_creds, user_mismatch}`.
+- Password comparison uses `Rack::Utils.secure_compare` (constant-time).
+
+**`ConditionalAuthenticityToken`:**
+- Subclass of `Rack::Protection::AuthenticityToken`.
+- `call(env)`: returns `@app.call(env)` early if `env['cgminer_manager.admin_authed']` is set. Otherwise defers to the parent's CSRF check.
+- Rationale: a valid static Basic Auth credential is strictly stronger proof than a session cookie + CSRF token. Also lets operators curl admin routes during incidents.
+
+### `CgminerManager::SnapshotAdapter` (module)
+**File:** `lib/cgminer_manager/snapshot_adapter.rb`
+
+Shape translation only. Four methods:
+
+- `.sanitize(node)` — recursive. `Hash` → rebuild with `sanitize_key`-ed keys. `Array` → map. Scalar → pass-through.
+- `.sanitize_key(key)` — `key.to_s.downcase.tr(' ', '_').to_sym`. Note: `%` is preserved as-is (so `"Device Hardware%"` becomes `:'device_hardware%'`).
+- `.legacy_shape(snapshot, type)` — returns `[{type => resp[inner_key] || []}]` from a monitor envelope, or `nil` if the snapshot has an error or a nil response.
+- `.build_miner_data(configured_miners, snapshots)` — per-miner, builds `{summary:, devs:, pools:, stats:}` in the shape the legacy partials read.
+
+**Why key sanitization uses `tr(' ', '_')` but not `gsub('%', '_pct')`:** the partials were written when `cgminer_api_client::Miner#sanitized` was the source of keys. That method lowercases and underscores but leaves `%` alone. Monitor's Poller applies `%` → `_pct` to *sample metadata only* (for Prometheus-compatible metric names in the time-series collection). Snapshot `response` fields preserve the raw cgminer JSON, so the adapter should mirror `Miner#sanitized`, not the Poller's sample-meta normalization.
+
+### `CgminerManager::ViewMiner` / `CgminerManager::ViewMinerPool` (`Data.define`)
+**File:** `lib/cgminer_manager/view_miner.rb`
+
+**`ViewMiner(host, port, available, label)`** — stand-in for `CgminerApiClient::Miner` in HAML partials. Exposes `.available?`, `.host_port`, `.display_label`, `.to_s` (label when present, else `host_port`). Built via `.build(host, port, available, label = nil)` which coerces `port` to `Integer` and normalizes empty-string label to `nil`.
+
+**`ViewMinerPool(miners: [ViewMiner])`** — partitioning helpers: `.available_miners`, `.unavailable_miners`.
+
+Value-equality (from `Data.define`) matters because `_warnings.haml` does `@bad_chain_elements.uniq!`.
+
+### `CgminerManager::FleetQueryResult` + `FleetQueryEntry`
+**File:** `lib/cgminer_manager/fleet_query_result.rb`
+
+**`FleetQueryEntry(:miner, :ok, :response, :error)`** — one miner's result for a read command. `#ok?` is just `ok`.
+
+**`FleetQueryResult(:entries)`** — the envelope. `#ok_count`, `#failed_count`, `#all_ok?`.
+
+### `CgminerManager::FleetWriteResult` + `FleetWriteEntry`
+**File:** `lib/cgminer_manager/fleet_write_result.rb`
+
+Same shape as the Query variant but for writes. No `save_status` field (save-after-command is a pool-management idiom, not a general one).
+
+**`FleetWriteEntry(:miner, :status, :response, :error)`** — `status ∈ {:ok, :failed}`. `#ok?`, `#failed?`.
+
+**`FleetWriteResult(:entries)`** — `#ok_count`, `#failed_count`, `#all_ok?`, `#any_failed?`.
+
+## CLI
+
+### `bin/cgminer_manager`
+**File:** `bin/cgminer_manager` (7 lines, shebang + `exit CgminerManager::CLI.run(ARGV)`)
+
+Shebang executable. Adds `lib/` to the load path and delegates to `CLI.run(argv)`.
+
+## Test-only components (not packaged)
+
+### `FakeCgminer`
+**File:** `spec/support/fake_cgminer.rb`
+
+Shared with cgminer_api_client and cgminer_monitor. In-process TCP server that accepts a JSON request, looks up the command name in a fixtures hash, writes the canned response, closes.
+
+### `CgminerFixtures`
+**File:** `spec/support/cgminer_fixtures.rb`
+
+Shared fixtures file. Canned cgminer wire-format JSON responses.
+
+### `monitor_stubs.rb`
+**File:** `spec/support/monitor_stubs.rb`
+
+WebMock helpers that stub `cgminer_monitor`'s `/v2/*` responses from fixture files in `spec/fixtures/monitor/*.json`.
+
+### Real fleet harness
+**File:** `dev/screenshots/fake_cgminer_fleet.rb`
+
+Not a test helper per se — the screenshot-regeneration harness launches six real TCP listeners on `127.0.0.1:40281..40286` so Playwright can drive the UI end-to-end against actual cgminer-shaped RPC responses.

--- a/docs/data_models.md
+++ b/docs/data_models.md
@@ -1,0 +1,338 @@
+# Data Models
+
+cgminer_manager has no database, no ORM, no migrations. "Data models" here means the runtime value objects that flow through the HTTP layer and the service classes. Every one of them is either a `Data.define` immutable value object or a Ruby hash shape derived from an upstream (cgminer_monitor JSON response, cgminer RPC JSON response, or the `miners.yml` file).
+
+## Object graph
+
+```mermaid
+classDiagram
+    class Config {
+        <<Data.define>>
+        +monitor_url: String
+        +miners_file: String
+        +port: Integer
+        +bind: String
+        +log_format: String
+        +log_level: String
+        +session_secret: String
+        +stale_threshold_seconds: Integer
+        +shutdown_timeout: Integer
+        +monitor_timeout: Integer
+        +pool_thread_cap: Integer
+        +rack_env: String
+        +validate!() Config
+        +load_miners() Array
+        +production?() Boolean
+    }
+
+    class ViewMiner {
+        <<Data.define>>
+        +host: String
+        +port: Integer
+        +available: Boolean
+        +label: String?
+        +available?() Boolean
+        +host_port() String
+        +display_label() String
+        +to_s() String
+    }
+
+    class ViewMinerPool {
+        <<Data.define>>
+        +miners: Array~ViewMiner~
+        +available_miners() Array
+        +unavailable_miners() Array
+    }
+
+    class FleetQueryEntry {
+        <<Data.define>>
+        +miner: String
+        +ok: Boolean
+        +response: Object?
+        +error: StandardError?
+        +ok?() Boolean
+    }
+
+    class FleetQueryResult {
+        <<Data.define>>
+        +entries: Array~FleetQueryEntry~
+        +ok_count() Integer
+        +failed_count() Integer
+        +all_ok?() Boolean
+    }
+
+    class FleetWriteEntry {
+        <<Data.define>>
+        +miner: String
+        +status: Symbol
+        +response: Object?
+        +error: StandardError?
+        +ok?() Boolean
+        +failed?() Boolean
+    }
+
+    class FleetWriteResult {
+        <<Data.define>>
+        +entries: Array~FleetWriteEntry~
+        +ok_count() Integer
+        +failed_count() Integer
+        +all_ok?() Boolean
+        +any_failed?() Boolean
+    }
+
+    class PoolManager_MinerEntry {
+        <<Data.define>>
+        +miner: String
+        +command_status: Symbol
+        +command_reason: StandardError?
+        +save_status: Symbol
+        +save_reason: StandardError?
+        +ok?() Boolean
+        +failed?() Boolean
+    }
+
+    class PoolActionResult {
+        <<Data.define>>
+        +entries: Array~MinerEntry~
+        +all_ok?() Boolean
+        +any_failed?() Boolean
+        +successful() Array
+        +failed() Array
+        +indeterminate() Array
+    }
+
+    FleetQueryResult "1" *-- "many" FleetQueryEntry
+    FleetWriteResult "1" *-- "many" FleetWriteEntry
+    PoolActionResult "1" *-- "many" PoolManager_MinerEntry
+    ViewMinerPool "1" *-- "many" ViewMiner
+```
+
+## Runtime value objects
+
+### `Config`
+
+Immutable 14-field config built from `ENV`. See `components.md` → `Config` for the full field list and defaults, and `interfaces.md` → environment-variable config for the env-var mapping.
+
+Invariants (enforced by `#validate!`):
+- `monitor_url` is set and non-empty.
+- `miners_file` exists on disk.
+- `log_format ∈ {"json", "text"}`.
+- `log_level ∈ {"debug", "info", "warn", "error"}`.
+
+Immutable by design; no hot reload. Restart to change.
+
+### `ViewMiner`
+
+Value object used in HAML partials wherever a `CgminerApiClient::Miner` instance was originally passed (in the Rails era). Built via `ViewMiner.build(host, port, available, label = nil)` which coerces `port` to Integer and normalizes empty-string labels to nil.
+
+Public surface:
+- `#host`, `#port`, `#available`, `#label` (attr readers).
+- `#available?` — alias for `available`.
+- `#host_port` — `"#{host}:#{port}"`.
+- `#display_label` — `label || host_port`.
+- `#to_s` — same as `display_label`.
+
+Value-equality from `Data.define` matters because `_warnings.haml` does `@bad_chain_elements.uniq!`.
+
+### `ViewMinerPool`
+
+Wraps `Array<ViewMiner>`. Two helpers:
+- `#available_miners` — `miners.select(&:available?)`.
+- `#unavailable_miners` — `miners.reject(&:available?)`.
+
+Built two ways:
+- `HttpApp#build_view_miner_pool(monitor_miners)` — for the dashboard, takes monitor's `/v2/miners` list (which carries `available:` flags).
+- `HttpApp#build_view_miner_pool_from_yml` — for per-miner pages, builds from `configured_miners` with everyone flagged `available: false` (availability isn't needed for the pool-wide sidebar on those pages).
+
+### `FleetQueryEntry` and `FleetQueryResult`
+
+Returned by `CgminerCommander#version`, `#stats`, `#devs`.
+
+`FleetQueryEntry`:
+- `miner` — `"host:port"` string (from the monkey-patched `Miner#to_s`).
+- `ok` — Boolean. `true` if the RPC succeeded and cgminer returned a non-error STATUS.
+- `response` — the parsed cgminer response. Shape depends on the command (e.g., `{STATUS: [...], VERSION: [...]}` for `:version`).
+- `error` — `StandardError` instance when `ok` is false; nil otherwise. Always one of `CgminerApiClient::{ConnectionError, TimeoutError, ApiError}`.
+
+`FleetQueryResult`:
+- `entries` — frozen array (from `Data.define`), preserving miner order.
+- `#ok_count`, `#failed_count`, `#all_ok?`.
+
+### `FleetWriteEntry` and `FleetWriteResult`
+
+Returned by `CgminerCommander#zero!`, `#save!`, `#restart!`, `#quit!`, `#raw!`.
+
+`FleetWriteEntry`:
+- `miner` — `"host:port"` string.
+- `status` — `:ok` or `:failed`. (Note the two-state model — writes don't have `:indeterminate` because there's no verification step here. Contrast with `PoolManager::MinerEntry`.)
+- `response` — parsed cgminer response on success, nil on failure.
+- `error` — `StandardError` on failure, nil on success.
+
+`FleetWriteResult`:
+- `entries` — frozen array, in miner order.
+- `#ok_count`, `#failed_count`, `#all_ok?`, `#any_failed?`.
+
+### `PoolManager::MinerEntry` and `PoolManager::PoolActionResult`
+
+Returned by every `PoolManager` method.
+
+`MinerEntry`:
+- `miner` — `"host:port"`.
+- `command_status` — `:ok` / `:failed` / `:indeterminate` / `:skipped` (the last is unusual; only appears for save_status).
+- `command_reason` — `StandardError` when `command_status` is `:failed` or `:indeterminate`, nil otherwise.
+- `save_status` — `:ok` / `:failed` / `:skipped`. `:skipped` when the command step failed (no point saving) or when the caller was `run_unverified`.
+- `save_reason` — `StandardError` or nil.
+- `#ok?` — both statuses are `:ok`.
+- `#failed?` — `command_status == :failed` (an indeterminate command that succeeded in saving is *not* "failed"; it's still `indeterminate`).
+
+Three-state `command_status` semantics:
+- `:ok` — the write succeeded, and (for verified operations like enable/disable/remove) the post-write query confirmed the expected state.
+- `:failed` — the write raised a `CgminerApiClient` error (connection, timeout, or API-level).
+- `:indeterminate` — the write returned without error, but the post-write verification saw an unexpected state (raised `PoolManagerError::DidNotConverge`).
+
+`PoolActionResult`:
+- `entries` — frozen array.
+- `#all_ok?`, `#any_failed?`, `#successful`, `#failed`, `#indeterminate` — the last three return sub-arrays of entries.
+
+### Upstream: monitor's `/v2/*` envelope (consumed, not owned)
+
+The manager parses these JSON shapes from `cgminer_monitor`. It does not define them — they belong to the monitor's contract — but it's worth summarizing what the manager relies on.
+
+`/v2/miners`:
+```json
+{"miners": [{"id": "host:port", "host": "h", "port": p, "available": true, "last_poll": "2026-04-19T..."}]}
+```
+
+`/v2/miners/:id/{summary,devices,pools,stats}`:
+```json
+{"miner": "host:port", "command": "summary", "fetched_at": "2026-04-19T...", "ok": true,
+ "response": {"STATUS": [...], "SUMMARY": [...]}, "error": null}
+```
+
+`/v2/graph_data/:metric`:
+```json
+{"miner": "host:port" | null, "metric": "hashrate", "since": "2026-04-19T...", "until": "2026-04-19T...",
+ "fields": ["ts", "ghs_5s", "ghs_av", "device_hardware_pct", "device_rejected_pct", "pool_rejected_pct", "pool_stale_pct"],
+ "data": [[1700000000, 14000000.0, ...], ...]}
+```
+
+`MonitorClient` parses these with `symbolize_names: true` so the manager sees `:miners`, `:summary`, `:fetched_at`, etc.
+
+## Shape translations
+
+### `SnapshotAdapter.legacy_shape`
+
+Turns monitor's `/v2/miners/:id/:type` envelope into the shape legacy partials expect.
+
+**Input** (monitor envelope, symbolized):
+```ruby
+{miner: "192.168.1.10:4028", command: "summary", fetched_at: "2026-04-19T...",
+ ok: true,
+ response: {"STATUS" => [...], "SUMMARY" => [{"MHS 5s" => 14000000.0, "Device Hardware%" => 0.0, ...}]},
+ error: nil}
+```
+
+**Output** (legacy partial shape):
+```ruby
+[{summary: [{mhs_5s: 14000000.0, :"device_hardware%" => 0.0, ...}]}]
+```
+
+Translations applied:
+1. `response[COMMAND_KEY_UPCASE]` → inner array. Pass-through — no key rewriting at that level.
+2. Each element's keys are deeply sanitized: `downcase.tr(' ', '_').to_sym`. Note that `%` is preserved.
+3. Wrap the result in `[{type: inner_array}]` so the partial can do `@miner_data[i][:summary].first[:summary]`.
+
+Returns `nil` when the snapshot has `:error` set or `:response` is nil, letting the partials render "waiting for first poll" / "data source unavailable" placeholders.
+
+### `SnapshotAdapter.sanitize_key`
+
+```ruby
+def self.sanitize_key(key)
+  key.to_s.downcase.tr(' ', '_').to_sym
+end
+```
+
+Preserves `%` verbatim: `"Device Hardware%"` → `:"device_hardware%"`. Intentional — this mirrors `cgminer_api_client::Miner#sanitized` (which the legacy partials were written against), not monitor's Poller normalization (which applies `%` → `_pct` for time-series sample metadata only).
+
+## In-request transient state
+
+### `@miner_data` (Array of Hashes)
+
+Built by `HttpApp`'s dashboard and per-miner routes via `SnapshotAdapter.build_miner_data(configured_miners, snapshots)`. Shape:
+
+```ruby
+[
+  {summary: [{summary: [...]}] | nil, devs: [{devs: [...]}] | nil,
+   pools: [{pools: [...]}] | nil, stats: [{stats: [...]}] | nil},
+  ... one per configured miner ...
+]
+```
+
+Index in the outer array = index in `HttpApp.configured_miners` = stable order from `miners.yml`.
+
+### `@miner_pool` (ViewMinerPool)
+
+See `ViewMinerPool` above.
+
+### `@view` (Hash)
+
+Returned by `build_dashboard_view_model` (for `/`) or `build_miner_view_model` (for `/miner/:id`).
+
+Dashboard shape:
+```ruby
+{miners: [...monitor's miners list OR fallback...],
+ snapshots: {"host:port" => {summary:, devices:, pools:, stats:}, ...},
+ banner: nil | "data source unavailable (...)",
+ stale_threshold: 300}
+```
+
+Per-miner shape:
+```ruby
+{miner_id: "host:port",
+ snapshots: {summary:, devices:, pools:, stats:}}
+```
+
+Each snapshot value is either a monitor envelope (the `{miner:, command:, fetched_at:, ok:, response:, error:}` shape above) or `{error: "<msg>"}` when `safe_fetch` caught a `MonitorError`.
+
+### `@request_id` (String, admin routes only)
+
+`SecureRandom.uuid` set in the `before` filter when `admin_path?(request.path_info)`. Threaded through every admin audit log event in the same request. Absent on non-admin routes.
+
+## Error class hierarchy
+
+```mermaid
+classDiagram
+    StandardError <|-- Error
+    Error <|-- ConfigError
+    Error <|-- MonitorError
+    MonitorError <|-- ConnectionError
+    MonitorError <|-- ApiError
+    Error <|-- DidNotConverge
+
+    class Error { <<CgminerManager::Error>> }
+    class ConfigError { raised by Config#validate!, CLI exit 2 }
+    class MonitorError { base for upstream HTTP failures }
+    class ConnectionError { <<MonitorError::ConnectionError>> }
+    class ApiError {
+        <<MonitorError::ApiError>>
+        +status: Integer
+        +body: String
+    }
+    class DidNotConverge { <<PoolManagerError::DidNotConverge>> }
+```
+
+All gem-specific errors descend from `CgminerManager::Error < StandardError`. `rescue CgminerManager::Error` catches everything.
+
+Where they're raised:
+
+| Error | Raised by | Trigger |
+|---|---|---|
+| `ConfigError` | `Config.from_env` / `#validate!` | bad env var, missing miners.yml, invalid log config |
+| `ConfigError` | `HttpApp.validate_miners_shape!` | miners.yml has wrong shape (not an Array, or an entry without `host`) |
+| `MonitorError::ConnectionError` | `MonitorClient#get` | `HTTP::ConnectionError`, `HTTP::TimeoutError`, `Errno::ECONNREFUSED` |
+| `MonitorError::ApiError` | `MonitorClient#get` | non-2xx HTTP response from monitor |
+| `PoolManagerError::DidNotConverge` | `PoolManager#verify_pool_state`, `#verify_pool_absent` | post-write query shows unexpected pool state, or verification timed out |
+
+`HttpApp#build_dashboard_view_model` and `#safe_fetch` catch `MonitorError` at the boundary and produce fallback UI state rather than propagating the error to the user. The CLI (`doctor`) catches `MonitorError` and reports it as a check failure.
+
+`PoolManagerError::DidNotConverge` is caught internally by `PoolManager#safe_call` and translated into `command_status: :indeterminate` — it never escapes to the route handler or to callers of `PoolActionResult`.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,110 @@
+# Dependencies
+
+## Runtime dependencies
+
+From the gemspec:
+
+| Gem | Constraint | Purpose |
+|---|---|---|
+| `cgminer_api_client` | `~> 0.3` | TCP client for cgminer. Used by `CgminerCommander` and `PoolManager` for write-path RPC; used by `bin/cgminer_manager doctor` for per-miner TCP reachability checks. |
+| `sinatra` | `~> 4.0` | HTTP app framework. `HttpApp < Sinatra::Base`. |
+| `sinatra-contrib` | `~> 4.0` | Provides `Sinatra::ContentFor` helper used by the layout for block content. |
+| `haml` | `~> 6.3` | Template engine. All views under `views/**/*.haml`. |
+| `http` | `~> 5.2` | HTTP client gem for calling `cgminer_monitor`. Used via `MonitorClient`. (Not Faraday; not Net::HTTP.) |
+| `puma` | `~> 6.4` | HTTP server. Embedded via `Puma::Configuration` + `Puma::Launcher`. |
+| `rack-protection` | `~> 4.0` | CSRF + other Rack-level protections. `ConditionalAuthenticityToken` subclasses `Rack::Protection::AuthenticityToken`. |
+
+Plus the Ruby stdlib pieces: `json`, `yaml`, `securerandom`, `digest`, `cgi`, `time`, plus `rack`, `rack/auth/basic`, `rack/session/cookie` (pulled in through the above).
+
+**No MongoDB.** The 1.0 rewrite dropped Mongoid entirely. Manager does not talk to any database — it's a pure HTTP-and-templates service. Persistent state lives in monitor's MongoDB (accessed via monitor's HTTP API) and in cgminer itself (accessed via TCP).
+
+**No asset pipeline.** No Sprockets, no Webpacker, no ESBuild. CSS and JS under `public/css/` and `public/js/` are served as-is by Puma. Cache-busting is done at the helper level via `?v=<VERSION>` appended to asset URLs (see `asset_url`, `stylesheet_link_tag`, `javascript_include_tag` helpers in `http_app.rb`).
+
+## Dev dependencies
+
+From `Gemfile`:
+
+```ruby
+group :development, :test do
+  gem 'parallel', '< 2.0'
+  gem 'rack-test',     '>= 2.1'
+  gem 'rake',          '>= 13.2'
+  gem 'rspec',         '>= 3.13'
+  gem 'rubocop',       '>= 1.60'
+  gem 'rubocop-rake',  '>= 0.6'
+  gem 'rubocop-rspec', '>= 2.27'
+  gem 'simplecov',     '>= 0.22'
+  gem 'webmock',       '>= 3.23'
+end
+```
+
+| Gem | Used for |
+|---|---|
+| `parallel` | Pinned `< 2.0` because parallel 2.x requires Ruby >= 3.3 and we need to keep the Ruby 3.2 CI lane green. Transitive dep of `rubocop` / `rubocop-ast`. |
+| `rack-test` | HTTP-level specs. Provides `Rack::Test::Methods` for making synthetic requests against `HttpApp` without booting Puma. |
+| `rake` | Task runner. `Rakefile` defines `default: [rubocop, spec]`. |
+| `rspec` | Test framework. Unit + integration. |
+| `rubocop`, `rubocop-rake`, `rubocop-rspec` | Linter and plugins. |
+| `simplecov` | Code coverage. Started in `spec_helper.rb` with coverage enforcement gated by `ENFORCE_COVERAGE=1` (set automatically by the rake task, not set when running filtered specs directly). |
+| `webmock` | Stubs outbound HTTP calls to `cgminer_monitor`. See `spec/support/monitor_stubs.rb` for the helper module. |
+
+## Ruby version support
+
+- **Minimum: Ruby 3.2.** Enforced by `spec.required_ruby_version = '>= 3.2'`.
+  - `Data.define` (used in `Config`, `ViewMiner`, `FleetQueryResult`, `FleetWriteResult`, `PoolManager::MinerEntry`, `PoolManager::PoolActionResult`) requires 3.2+.
+  - Endless method definitions (used throughout: `def method = ...`) require 3.0+.
+- **CI-tested: 3.2, 3.3, 3.4.** Must-pass.
+- **Best-effort: 4.0, head.** Via the nightly workflow (`.github/workflows/nightly.yml`). Allowed to fail.
+- **Local dev pin:** `.ruby-version` = 4.0.2. Only affects contributors.
+
+**Sharp edges:**
+- `parallel` 2.x requires Ruby 3.3. Pinned to `< 2.0` in the Gemfile so Ruby 3.2 can still bundle.
+- Haml 6 (not Haml 5) is required. Haml 5 and 6 have different internal APIs around `html_safe?` stamping — the `raw` and `html_safe` helpers in `http_app.rb` depend on Haml 6 semantics.
+
+## CI matrix (`.github/workflows/ci.yml`)
+
+Three jobs, plus a separate nightly:
+
+### `lint`
+- Single lane: Ruby 3.4 on `ubuntu-latest`.
+- Runs `bundle exec rubocop`.
+- Separated so rubocop failures don't block the test matrix.
+
+### `test`
+- Matrix: Ruby 3.2 / 3.3 / 3.4.
+- Runs `bundle exec rspec --tag ~integration` (unit only).
+
+### `integration`
+- Single lane: Ruby 3.4.
+- Runs `bundle exec rspec --tag integration`.
+- Slower (HTTP + rack-test flows).
+
+### `nightly` (separate workflow, `.github/workflows/nightly.yml`)
+- Runs Ruby 4.0 and `head` lanes.
+- Allowed to fail (marked experimental).
+- Early-warning signal for upcoming Ruby versions.
+
+Triggers: `push` and `pull_request` on `develop` or `master`. PR `concurrency:` configured to cancel in-progress runs on new pushes; push-to-branch runs let previous runs finish.
+
+## External dependencies (not Ruby gems)
+
+- **`cgminer_monitor`** — runtime requirement, 1.0+. Supplies the read-path data. The manager's `doctor` subcommand hard-fails if monitor is unreachable.
+- **cgminer instances** — not strictly required for the manager to *boot*, but all write-path operations (pool mgmt, admin RPC) and the legacy `/api/v1/ping.json` endpoint need TCP reachability.
+- **Docker** (optional dev) — `docker-compose.yml` wires manager + monitor + mongo. Not required if you want to run monitor and mongo separately.
+
+## Dependency update strategy
+
+No Dependabot or Renovate configured. Manual bumps when needed. Minimum-version constraints are intentionally loose (`rspec >= 3.13`, `sinatra ~> 4.0`, etc.) so Bundler resolves current versions without over-constraining consumers.
+
+`Gemfile.lock` is `.gitignore`d — consumers generate their own.
+
+## Why the dependency set is small
+
+Intentional. The 0.x Rails-engine era had Rails 4.2, Mongoid 4, Thin, therubyracer, Sprockets, jquery-rails, sass-rails, coffee-rails, Bootstrap via Sass. The 1.0 rewrite deleted all of that in favor of hand-written HAML + vanilla JS + Chart.js served from `public/`. The net result:
+
+- No asset-pipeline maintenance burden.
+- No Rails upgrade cadence.
+- No Mongoid-Rails version compatibility matrix.
+- Fewer transitive deps → faster `bundle install`, smaller container images.
+
+The trade-off is that a few Rails conveniences (URL helpers, asset helpers, `time_ago_in_words`) had to be hand-rolled in `http_app.rb` helpers. Those are stable now; don't reach for more Rails-like sugar without a reason.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,73 @@
+# Knowledge Base Index — `cgminer_manager`
+
+**This file is the entry point for AI assistants working on `cgminer_manager`.** It summarizes every other document in `docs/` so an assistant can pull in only the file(s) relevant to a given question. When no single file is an obvious fit, read `AGENTS.md` (consolidated, at repo root) or skim `codebase_info.md` first.
+
+## How to use this index
+
+1. **Identify the question category** from the table below (Architecture? HTTP API? Admin surface? Operational concern?).
+2. **Read the mapped file.** Each mapping includes a one-line "use this when" hook plus a brief summary below.
+3. **Cross-reference** via the explicit links between documents — they're maintained.
+4. **Fall back** to reading the code. All docs are derived from `lib/`, `bin/`, `views/`, and `spec/`; if a doc and the code disagree, the code is truth and the doc is stale (please flag it).
+
+## Question → file map
+
+| If the question is about... | Start here |
+|---|---|
+| "what is this project?" / stack / file tree / module graph | [`codebase_info.md`](codebase_info.md) |
+| two-upstream model (monitor HTTP + cgminer TCP) / signal dance / admin request lifecycle / CSRF ↔ Basic Auth interaction / audit logging | [`architecture.md`](architecture.md) |
+| what each class/module does / where a piece of behavior lives | [`components.md`](components.md) |
+| HTTP routes / CLI exit codes / env-var table / `miners.yml` schema / structured log schema | [`interfaces.md`](interfaces.md) |
+| `Data.define` value objects / `Config` invariants / `SnapshotAdapter` shape translation / error hierarchy | [`data_models.md`](data_models.md) |
+| startup / dashboard render / pool ops / admin flow / graceful shutdown / test harness / release | [`workflows.md`](workflows.md) |
+| runtime + dev deps / Ruby version floors / CI matrix / why no Rails/Mongoid | [`dependencies.md`](dependencies.md) |
+| known doc/code drift / dead or unwired code paths / cleanup recommendations | [`review_notes.md`](review_notes.md) |
+
+## Document summaries
+
+### [`codebase_info.md`](codebase_info.md)
+**Purpose:** The one-pager. What cgminer_manager is (Sinatra web UI on top of cgminer_monitor + cgminer_api_client), what Ruby/Mongo versions it requires (Ruby 3.2+, no Mongo), full file tree, and a high-level module graph showing the two upstream dependencies. **Start here if you've never seen the project.**
+
+### [`architecture.md`](architecture.md)
+**Purpose:** Why the code is shaped the way it is. Covers: the single-process-two-signal-handler-installs Puma model, the signal-handler reinstall dance around Puma's `setup_signals`, the dashboard request lifecycle (parallel fan-out to monitor tiles), the admin request lifecycle (AdminAuth → ConditionalAuthenticityToken → command validation → scope check → audit-logged fan-out), the pool-management write-verify-save pattern, graceful shutdown, and the ergonomic-vs-defensive distinction for the admin surface. **Read this before making non-trivial structural changes.**
+
+### [`components.md`](components.md)
+**Purpose:** Catalog of every file in `lib/cgminer_manager/` with responsibilities, key public methods, and call-out gotchas. Includes the CLI subcommand table, the `AdminAuth` + `ConditionalAuthenticityToken` middleware pair, `SnapshotAdapter`'s shape-translation job, the three-state `PoolManager::MinerEntry` semantics, and the monkey-patched `CgminerApiClient::Miner#to_s` at the top of `http_app.rb`. **Read this to find where a specific piece of behavior lives.**
+
+### [`interfaces.md`](interfaces.md)
+**Purpose:** Exhaustive contract reference. All 14 HTTP routes with method/path/purpose/response type. CLI subcommands and exit codes (0/1/2/64). Env-var config table (14 vars). `miners.yml` schema. CSRF + Basic Auth interaction rules. Scope restrictions list (which admin verbs refuse `scope=all`). Graph-data response shape per metric. Structured log event catalog. **Read this for API/CLI/config questions.**
+
+### [`data_models.md`](data_models.md)
+**Purpose:** Runtime data shapes. `Config`, `ViewMiner`/`ViewMinerPool`, `FleetQueryResult`/`FleetWriteResult` + their entry types, `PoolManager::MinerEntry` (with three-state command_status), monitor's `/v2/*` JSON envelope. The `SnapshotAdapter` shape translation (input vs output example). Error class hierarchy with raise-site table. **Read this for "what's in this object" questions.**
+
+### [`workflows.md`](workflows.md)
+**Purpose:** Sequence diagrams + step-by-step flows. Startup (signal-handler dance), dashboard render (snapshot fan-out), pool management (write + verify + save), admin run (AdminAuth + CSRF + command validation + scope check + commander fan-out), graceful shutdown. Plus dev workflows (running tests, regenerating screenshots, refreshing monitor fixtures) and release process. **Read this to understand how code paths compose over time.**
+
+### [`dependencies.md`](dependencies.md)
+**Purpose:** Runtime deps (cgminer_api_client, Sinatra, sinatra-contrib, Puma, HAML, http, rack-protection — no MongoDB, no Rails), dev deps (rspec, webmock, rack-test, rubocop, simplecov, parallel pinned <2.0). Ruby version rationale (3.2+ for `Data.define` and endless methods). CI matrix (lint + test matrix + integration, plus nightly for 4.0/head). Why the dep set is small (the 1.0 rewrite deleted Rails/Mongoid/Sprockets). **Read this for "can I add gem X?" or "why is parallel pinned?" questions.**
+
+### [`review_notes.md`](review_notes.md)
+**Purpose:** Self-audit. Cross-file consistency check (passed). Known gaps in the code (`Config.monitor_timeout` not plumbed, miners.yml shape errors surface as HTTP 500 not CLI exit 2, inline `ENV['SESSION_SECRET']` bypassing `Config.session_secret`, no OpenAPI parity check, per-request thread-pool spawn, no `brakeman`). Gaps in these docs themselves. Recommendations with effort/value triage. **Read this before trusting a confident-sounding claim elsewhere in these docs.**
+
+## Example queries and where to go
+
+| Query | Primary file(s) |
+|---|---|
+| "How do I add a new HTTP route?" | `components.md` (HttpApp) + `interfaces.md` (current route list) + root `AGENTS.md` for the exact step list |
+| "How do I add a new graph metric?" | `architecture.md` (read path) + `interfaces.md` (graph response shape) + `components.md` (HttpApp `GRAPH_METRIC_PROJECTIONS`) |
+| "What happens when monitor is down but some cgminers are up?" | `architecture.md` (dashboard read path) + `workflows.md` (dashboard render) |
+| "Why can I curl `/manager/admin/run` when I send Basic Auth but not when I just send a cookie?" | `architecture.md` (CSRF ↔ Basic Auth interaction) + `components.md` (AdminAuth + ConditionalAuthenticityToken) |
+| "What error codes does the CLI use?" | `interfaces.md` (CLI section) + `review_notes.md` (gap #2 on 2 vs 78) |
+| "Where does `@miner_data` come from?" | `architecture.md` (dashboard flow) + `components.md` (SnapshotAdapter) + `data_models.md` (in-request transient state) |
+| "Can pool management survive a transient cgminer error?" | `components.md` (PoolManager three-state) + `data_models.md` (MinerEntry) + `workflows.md` (pool flow) |
+| "What version of Ruby can I use?" | `dependencies.md` |
+| "What's logged when an admin command runs?" | `interfaces.md` (log event catalog) + `architecture.md` (admin audit log schema) |
+
+## Maintenance note
+
+These docs were generated by analyzing 1.2.0 source. They reflect the state at that release. When the code changes substantially:
+
+- Prefer updating the specific file that contains the affected claim (smaller diffs, clearer history).
+- Update `review_notes.md` if you find a new inconsistency or gap.
+- Re-run the codebase-summary skill in `update_mode=true` if the surface area has shifted enough to warrant a re-analysis.
+
+If you're an AI assistant and you find a doc that contradicts the current code, **trust the code** and flag the discrepancy to the maintainer rather than silently fixing the doc.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,223 @@
+# Interfaces
+
+`cgminer_manager` has four surfaces:
+
+1. The **CLI** (`cgminer_manager` binary).
+2. The **environment-variable config**.
+3. The **`miners.yml`** file.
+4. The **HTTP API + UI** served by the embedded Puma.
+
+And it consumes two external interfaces:
+
+5. **`cgminer_monitor`'s `/v2/*` API** over HTTP.
+6. **cgminer instances** directly over TCP via `cgminer_api_client`.
+
+## 1. CLI
+
+### Binary
+
+```
+cgminer_manager <command>
+```
+
+### Subcommands
+
+| Command | Purpose | Exit codes |
+|---|---|---|
+| `run` | Start the Sinatra service in the foreground. Blocks until SIGTERM/SIGINT. | `0` clean shutdown; `2` config error from `Config.from_env` |
+| `doctor` | Check monitor reachability, each cgminer's TCP reachability, and consistency between `miners.yml` and monitor's `/v2/miners`. Read-only. | `0` all checks passed, `1` at least one failure, `2` config error |
+| `version` | Print `CgminerManager::VERSION`. | `0` |
+| anything else / missing | Print `unknown verb:` to stderr + usage line. | `64` |
+
+Exit code semantics note: `2` is **not** a standard sysexits(3) code — `cgminer_monitor` uses `78` (`EX_CONFIG`) for the equivalent failure. The choice here predates that convergence and we've kept it for compatibility with existing systemd units.
+
+### Output streams
+
+**stdout:**
+- `run`: structured log lines. Format controlled by `LOG_FORMAT` (`json` by default in production, `text` by default in development).
+- `doctor`: human-readable check output (`  monitor /v2/miners: OK (3 miner(s))`, `  cgminer 192.168.1.10:4028: reachable`, etc.), then `doctor: all checks passed` on success.
+- `version`: one line.
+
+**stderr:**
+- `unknown verb: …` + usage line.
+- `config error: <msg>` — `ConfigError` rescued at the CLI boundary.
+- `doctor`: `  FAIL: …` lines listed after the positive checks on failure.
+- One-off dev-only warning from `Config.resolve_session_secret`: `[cgminer_manager] SESSION_SECRET unset; generating ephemeral secret (dev only)` — not structured, written with `warn` before the logger is configured.
+
+Library code inside `lib/` never writes to `$stderr` directly — everything flows through `CgminerManager::Logger` to stdout. The only direct `warn` calls are in the CLI and in the session-secret fallback.
+
+### `doctor` detail
+
+The `doctor` subcommand performs three checks:
+
+1. Reach `cgminer_monitor` at `CGMINER_MONITOR_URL` via `GET /v2/miners`. Record the miner count.
+2. For each entry in `miners.yml`: open a TCP socket to `host:port` (via `CgminerApiClient::Miner#available?`) and report reachable or not.
+3. For each entry in `miners.yml`: check that the same `host:port` appears in monitor's `/v2/miners` list. Missing entries are an explicit failure.
+
+Non-zero exit on any failure. No attempt to mutate anything.
+
+## 2. Environment-variable config
+
+Parsed once at boot by `Config.from_env`, validated in `Config#validate!`. Defaults in parentheses.
+
+| Variable | Purpose |
+|---|---|
+| `CGMINER_MONITOR_URL` | Base URL of cgminer_monitor (e.g. `http://localhost:9292`). **Required.** No default. |
+| `MINERS_FILE` | Path to miners YAML. Default `config/miners.yml`. Must exist at boot. |
+| `PORT` | Puma bind port. Default `3000`. |
+| `BIND` | Puma bind address. Default `127.0.0.1`. |
+| `SESSION_SECRET` | Signs session cookies. **Required in production**; dev generates an ephemeral one with a stderr warning. |
+| `CGMINER_MANAGER_ADMIN_USER` | Basic Auth username for admin routes. Read per-request by `AdminAuth`. Empty = unset. |
+| `CGMINER_MANAGER_ADMIN_PASSWORD` | Basic Auth password. Paired with `_USER`. Both must be set (non-empty) to enable the gate. |
+| `LOG_FORMAT` | `json` (default in prod) or `text` (default in dev). |
+| `LOG_LEVEL` | `debug` / `info` / `warn` / `error`. Default `info`. |
+| `STALE_THRESHOLD_SECONDS` | UI staleness badge threshold. Default `300`. |
+| `SHUTDOWN_TIMEOUT` | Seconds to wait for Puma to stop after SIGTERM. Default `10`. |
+| `MONITOR_TIMEOUT_MS` | HTTP timeout for monitor calls. Default `2000`. (Note: not currently plumbed through to `MonitorClient` — see `review_notes.md`.) |
+| `POOL_THREAD_CAP` | Thread cap for `CgminerCommander` + `PoolManager` + dashboard snapshot fan-out. Default `8`. |
+| `RACK_ENV` | Passed to Puma and used to gate dev vs. production defaults. Default `development`. |
+
+`Config#validate!` fails hard (raises `ConfigError`, CLI maps to exit 2) on: missing `CGMINER_MONITOR_URL`, missing `miners_file`, unknown `log_format`, unknown `log_level`. Integer parsing errors name the offending env var.
+
+## 3. `miners.yml`
+
+YAML array of miner descriptors. Loaded by `HttpApp.configured_miners` (memoized at first access) and by `Config#load_miners` (used by `doctor`).
+
+```yaml
+- host: 192.168.1.10
+  port: 4028
+- host: 192.168.1.11
+  port: 4028
+  label: main rig
+- host: miner3.local
+  # port defaults to 4028
+```
+
+| Key | Required | Type | Default |
+|---|---|---|---|
+| `host` | yes | string | — |
+| `port` | no | integer | `4028` |
+| `label` | no | string | nil (UI falls back to `host:port`) |
+
+Parsed with `YAML.safe_load_file`. `HttpApp.parse_miners_file` validates the shape: must be a `Array<Hash>` where every entry has a `host` key. Invalid shapes raise `ConfigError`.
+
+## 4. HTTP API + UI
+
+Base URL: `http://<BIND>:<PORT>/` (default `http://127.0.0.1:3000/`).
+
+### Routes
+
+| Method | Path | Purpose | Response type |
+|---|---|---|---|
+| GET | `/` | Dashboard (Summary / Miner Pool / Admin tabs). | `text/html` |
+| GET | `/miner/:miner_id` | Per-miner page (Miner / Devs / Pools / Stats / Admin tabs). `:miner_id` is URL-encoded `host:port`. | `text/html` |
+| GET | `/graph_data/:metric` | Dashboard-aggregate graph data. `:metric` ∈ `{hashrate, temperature, availability}`. Optional `since` query (passes through to monitor). | `application/json` |
+| GET | `/miner/:miner_id/graph_data/:metric` | Per-miner graph data. Same metric set. | `application/json` |
+| POST | `/manager/manage_pools` | Fleet-wide pool op. Params: `action_name` ∈ `{enable, disable, remove, add}`, `pool_index` (for enable/disable/remove), `url`/`user`/`pass` (for add). CSRF-protected. Returns a rendered partial. | `text/html` |
+| POST | `/miner/:miner_id/manage_pools` | Per-miner pool op. Same params. CSRF-protected. | `text/html` |
+| POST | `/manager/admin/:command` | Typed fleet admin. `:command` ∈ `{version, stats, devs, zero, save, restart, quit}`. CSRF-protected; Basic Auth when configured. | `text/html` |
+| POST | `/manager/admin/run` | Raw fleet admin. Params: `command` (matches `ADMIN_RAW_COMMAND_PATTERN`), `args` (comma-separated positional), `scope` (`all` or a configured `host:port`). 422 on pattern mismatch or scope rejection. CSRF-protected; Basic Auth when configured. | `text/html` |
+| POST | `/miner/:miner_id/admin/:command` | Typed per-miner admin. Same `:command` set. | `text/html` |
+| POST | `/miner/:miner_id/admin/run` | Raw per-miner admin. `scope=all` restriction does not apply (scope is already the one miner). | `text/html` |
+| GET | `/api/v1/ping.json` | Legacy probe. Returns `{timestamp, available_miners, unavailable_miners}` from cgminer-direct probes (independent of monitor). | `application/json` |
+| GET | `/healthz` | Service health. 200 if miners.yml parses and monitor `/v2/healthz` reachable, else 503 with a `reasons:` array. | `application/json` |
+
+Sinatra route order matches the file order in `http_app.rb`. Named captures (`:miner_id`, `:command`, `:metric`) are standard Sinatra — no custom router.
+
+### CSRF and Basic Auth interaction
+
+All `POST /manager/*` and `POST /miner/*` routes are CSRF-protected via `ConditionalAuthenticityToken`.
+
+Admin routes (`/manager/admin/*`, `/miner/:id/admin/*`) additionally pass through `AdminAuth`:
+
+- If `CGMINER_MANAGER_ADMIN_USER` *and* `CGMINER_MANAGER_ADMIN_PASSWORD` are both set (non-empty): require valid Basic Auth. Valid Basic Auth sets `env['cgminer_manager.admin_authed'] = true`, which `ConditionalAuthenticityToken` checks to bypass the token check.
+- Otherwise (either var empty/unset): `AdminAuth` passes through. CSRF still applies (browser path).
+
+Browser clients get the token via `csrf_meta_tag` in the layout and submit it via the `authenticity_token` hidden field. XHR clients can read the token from the meta tag and send it via the `X-CSRF-Token` header. Scripts/curl with valid Basic Auth skip CSRF.
+
+### Raw RPC arg escaping caveat
+
+`POST /manager/admin/run` and `POST /miner/:id/admin/run` pass `args` through `args.to_s.split(',')` before handing the array to `cgminer_api_client`'s `Miner#query`. **Commas inside argument values are not escapable through this form** — the split happens before the gem's own escape pass. Not a practical limitation for any common cgminer verb.
+
+### Scope restrictions
+
+These commands refuse `scope=all` with `422 + admin.scope_rejected` log when hit through `/manager/admin/run`:
+
+- `pgaset`, `ascset` — device clock / voltage tuning.
+- `pgarestart`, `ascrestart` — per-device restart with params.
+- `pgaenable`, `pgadisable`, `ascenable`, `ascdisable` — device enable/disable.
+
+The UI disables the "all" scope option when the command input matches — but the server-side regex is the defensive layer.
+
+### Graph data response shape
+
+The manager's `/graph_data/:metric` endpoints are a *projection* over monitor's `/v2/graph_data/:metric` response: monitor returns `{miner, metric, since, until, fields: [...], data: [[ts, v1, v2, ...], ...]}`; the manager strips the envelope and returns only the reordered `data` array, with each row columns reordered to a stable projection:
+
+| Metric | Columns returned |
+|---|---|
+| `hashrate` | `[ts, ghs_5s, ghs_av, device_hardware_pct, device_rejected_pct, pool_rejected_pct, pool_stale_pct]` |
+| `temperature` | `[ts, min, avg, max]` |
+| `availability` | `[ts, available, configured]` (dashboard) / `[ts, available]` (per-miner) |
+
+If monitor's response is missing a column (e.g., per-miner availability), the projection fills `nil` for that slot. The Chart.js frontend reads the array positions directly.
+
+### 4xx / 5xx responses
+
+- `400 Bad Request` — unknown `action_name` on manage_pools (`halt 400, "unknown action: ..."`, `text/plain`).
+- `404 Not Found` — unknown miner_id on per-miner routes, unknown metric on graph_data, unknown command on typed admin. Falls through to the `not_found do` block which renders `views/errors/404.haml` as HTML.
+- `422 Unprocessable Entity` — `ADMIN_RAW_COMMAND_PATTERN` mismatch, `SCOPE_RESTRICTED_VERBS` + `scope=all` (with `admin.scope_rejected` log), unknown scope. `text/plain` message.
+- `500 Internal Server Error` — unhandled exception in any route. Logs `http.500` with backtrace, renders `views/errors/500.haml`.
+
+### Request logging
+
+Every HTTP request emits an `http.request` log line in the `after` filter with `path`, `method`, `status`, `render_ms`. For admin routes the `before` filter generates a `request_id = SecureRandom.uuid` which threads through the admin audit events (see `architecture.md` → admin audit log schema).
+
+## 5. Upstream: `cgminer_monitor` `/v2/*`
+
+Hard runtime dependency. Read-path data source for the dashboard and per-miner pages.
+
+Endpoints consumed (via `MonitorClient`):
+
+- `GET /v2/miners` — enumerate configured miners on monitor side.
+- `GET /v2/miners/:id/{summary,devices,pools,stats}` — per-miner latest snapshots.
+- `GET /v2/graph_data/:metric` — time-series for graphs.
+- `GET /v2/healthz` — used by our own `/healthz`.
+
+Manager speaks to monitor over plain HTTP with a 2-second timeout (configurable via `MONITOR_TIMEOUT_MS`, though not yet plumbed through — see `review_notes.md`). Manager does **not** speak monitor's Prometheus `/metrics` or use its OpenAPI spec; we have our own OpenAPI gap (see `architecture.md` and `review_notes.md`).
+
+Manager requires `cgminer_monitor` 1.0+ (the release that introduced `/v2/*`). The 0.x Rails-engine monitor has no `/v2/*` and will fail manager's startup `doctor` check.
+
+## 6. Upstream: cgminer via `cgminer_api_client`
+
+Hard runtime dependency (`~> 0.3`). Write-path data source for pool management and admin RPC.
+
+Classes used:
+- `CgminerApiClient::Miner.new(host, port)` — one TCP client per request, no connection pooling. The monkey-patched `#to_s` (defined at the top of `http_app.rb`) returns `"host:port"` for display.
+- `CgminerApiClient::MinerPool` — not used directly by manager (both `CgminerCommander` and `PoolManager` build their own thread-pool fan-out).
+
+Errors caught and folded into result entries:
+- `CgminerApiClient::ConnectionError`
+- `CgminerApiClient::TimeoutError`
+- `CgminerApiClient::ApiError`
+
+Also caught but re-raised differently:
+- `CgminerManager::PoolManagerError::DidNotConverge` (raised by `PoolManager`'s verification helpers, captured into `MinerEntry.command_status = :indeterminate`).
+
+## Structured log schema
+
+Every log line is a JSON object (default in production) or tokenized text. Guaranteed fields: `ts`, `level`, `event`.
+
+Notable events (non-exhaustive):
+
+| Event | Emitter | Fields |
+|---|---|---|
+| `server.start`, `server.stopping`, `server.stopped` | Server | standard |
+| `puma.crash` | Server | `error`, `message` |
+| `http.request` | HttpApp (after filter) | `path`, `method`, `status`, `render_ms` |
+| `http.500` | HttpApp error handler | `error`, `message`, `backtrace` (first 10) |
+| `monitor.call` | MonitorClient | `url`, `status`, `duration_ms` |
+| `monitor.call.failed` | MonitorClient | `url`, `error`, `message` |
+| `admin.command`, `admin.raw_command` | HttpApp admin routes | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope`, `args` |
+| `admin.result` | HttpApp admin routes | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `elapsed_ms` |
+| `admin.scope_rejected` | HttpApp `/admin/run` | `request_id`, `command`, `scope` |
+| `admin.auth_failed` | AdminAuth | `reason`, `path`, `remote_ip`, `user_agent` |

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,0 +1,111 @@
+# Review Notes
+
+Self-audit of the documentation set. Honest list of what I couldn't fully verify, known gaps in the code, and the items I'd flag for cleanup work. Read this before trusting a confident-sounding claim elsewhere in `docs/`.
+
+## Consistency check
+
+I cross-referenced the following claims across files and found no contradictions:
+
+| Claim | Asserted in | Verified |
+|---|---|---|
+| Read path goes through `cgminer_monitor` over HTTP; write path goes direct to cgminer via `cgminer_api_client` over TCP | `codebase_info.md`, `architecture.md`, `components.md`, `workflows.md`, `interfaces.md` | consistent |
+| `Config` is an immutable `Data.define` | `codebase_info.md`, `architecture.md`, `components.md`, `data_models.md` | consistent |
+| `HttpApp` class-level state (monitor_url, miners_file, stale_threshold_seconds, pool_thread_cap, configured_miners) set by `Server#configure_http_app` | `codebase_info.md`, `architecture.md`, `components.md` | consistent |
+| CLI exit codes 0 / 1 / 2 / 64 | `interfaces.md`, `components.md`, `workflows.md` | consistent |
+| `Data.define` value objects for `ViewMiner`, `FleetQueryResult`, `FleetWriteResult`, `PoolActionResult` | `codebase_info.md`, `components.md`, `data_models.md` | consistent |
+| Admin surface is ergonomic-vs-defensive (allowlist is UI, defense is Basic Auth + scope restrictions + audit logging) | `architecture.md`, `components.md`, `interfaces.md` | consistent |
+| Signal-handler reinstall dance around Puma's `setup_signals` | `architecture.md`, `components.md`, `workflows.md` | consistent |
+
+Nothing contradictory. If later edits introduce drift, re-run this section.
+
+## Completeness gaps (in the code)
+
+### 1. `Config#monitor_timeout` is declared but not plumbed through
+
+`Config` has a `monitor_timeout` field (parsed from `MONITOR_TIMEOUT_MS`, default 2000). But `HttpApp#monitor_client` constructs `MonitorClient.new(base_url: self.class.monitor_url)` without passing `timeout_ms:`, so every monitor call uses the hardcoded 2-second default in `MonitorClient#initialize`.
+
+**Consequence:** `MONITOR_TIMEOUT_MS` does nothing today. Either wire it through `HttpApp.monitor_timeout_ms = @config.monitor_timeout` in `Server#configure_http_app` and pass it into `MonitorClient.new`, or remove the env var and the field.
+
+### 2. `2` vs `78` for `EX_CONFIG`
+
+`CLI#run` maps `ConfigError` to exit code `2`. `cgminer_monitor` uses `78` (`EX_CONFIG` per sysexits(3)) for the same failure. The convention across the three repos isn't consistent. Low-value to fix — operators don't usually key off these codes — but if you're already editing `cli.rb`, it's a one-line change to standardize.
+
+### 3. `HttpApp.configured_miners` validation raises `ConfigError` lazily
+
+`HttpApp.parse_miners_file` raises `ConfigError` if the miners.yml shape is invalid. But `configured_miners` is memoized lazily on first access, which means the first HTTP request after a bad miners.yml edit hits a 500 rather than the process failing to boot. `bin/cgminer_manager doctor` catches this early, but `run` doesn't validate miners.yml shape at startup.
+
+**Fix:** `Server#configure_http_app` could force-evaluate `HttpApp.configured_miners` after setting the class attrs, so miners.yml shape errors surface as `ConfigError` at CLI boundary (exit 2) rather than as HTTP 500s after boot.
+
+### 4. `Config.session_secret` is set but never passed into `Rack::Session::Cookie`
+
+`HttpApp`'s `Rack::Session::Cookie` middleware does `secret: ENV.fetch('SESSION_SECRET') { SecureRandom.hex(32) }` directly, bypassing the `Config.session_secret` resolution. So the dev-only "ephemeral secret" path happens twice (once in `Config.resolve_session_secret`, once inline in `HttpApp`), and `Config.session_secret` is never used.
+
+**Fix:** plumb `Config.session_secret` into `HttpApp` as a class attr and use it from the `configure do` block, so the single source of truth for session secret is `Config`.
+
+### 5. Dashboard and per-miner routes spawn thread pools per request
+
+`HttpApp#fetch_snapshots_for` and `HttpApp#build_commander_for_all` both spawn a fresh pool of threads for each request. Under load (dashboard auto-refresh at low interval, multiple operators refreshing, Prometheus scraping `/healthz` frequently) this creates thread churn.
+
+**Not a problem at current scale** (< 10 miners, < 10 operators), but if usage grows, consider a persistent worker pool per `HttpApp` instance. Documenting for future-you.
+
+### 6. No OpenAPI spec (unlike monitor)
+
+`cgminer_monitor` has an `openapi.yml` and a CI parity check that breaks the build when routes and spec drift. Manager has no OpenAPI spec. All 14 routes are documented here in `interfaces.md`, but there's no machine-checked parity.
+
+**If we want one:** follow monitor's pattern — add `lib/cgminer_manager/openapi.yml`, serve it at `/openapi.yml`, add a `spec/openapi_consistency_spec.rb`, add a CI job. Worth doing if a third party needs to build against the API; overkill for internal use.
+
+### 7. Admin audit log: `session_id_hash` truncation is cosmetic
+
+`admin_session_id_hash` returns `Digest::SHA256.hexdigest(sid)[0..11]` — 12 hex chars, 48 bits. Collisions are extraordinarily unlikely in a short log window, but not zero. Documenting because the comment in the code doesn't explain the trade-off: 12 chars is "short enough to eyeball across log entries, long enough that correlating two entries by the hash isn't attacker-useful even if the session ID is long-lived."
+
+### 8. Integration specs don't test real signal delivery
+
+`spec/integration/` tests HTTP routes via `rack-test` against `HttpApp` directly — they never boot the full `Server` with a real Puma listener and don't exercise the signal-handler reinstall path. That path is important (see `architecture.md`), and the only coverage is the `Server` unit spec which mocks the launcher. Same gap as cgminer_monitor had; no action needed unless we hit a real shutdown-path bug.
+
+### 9. `raw!` comma-split is documented but error-handling isn't
+
+`CgminerCommander#raw!` does `args.to_s.split(',')` and passes the array positionally. If an argument *has* to contain a comma, there's no escape. The README's "Raw RPC arg escaping caveat" section documents this at a policy level, but there's no defensive behavior in the code — a would-be-escaped comma goes through as a split delimiter. Matches cgminer's own arg-passing semantics; flagged because it's the kind of thing someone might "fix" without understanding why it's a deliberate pass-through.
+
+### 10. Sinatra app mounts `Rack::Session::Cookie` without `secure: true`
+
+Default session cookie settings are `same_site: :lax` but **not** `secure: true`. This is fine for the localhost-only default deployment but wrong-by-default if someone exposes the app to the public internet without a reverse proxy.
+
+**Not urgent** because the README's Security Posture section specifically says "put it behind a reverse proxy that provides authentication." But if we want belt-and-suspenders, we could conditionally set `secure: true` when `config.production?`.
+
+## Gaps in these docs
+
+- I didn't count lines in each partial or enumerate every helper method. The "~700 LOC" figure for `http_app.rb` is from `wc -l`, rounded.
+- I didn't exhaustively trace every CSS/JS file under `public/`. Chart.js lives there; the exact version isn't pinned here.
+- The CI workflow section in `dependencies.md` accurately describes `ci.yml` but only skims `nightly.yml` (I didn't read it end-to-end).
+- The screenshot harness in `dev/screenshots/` is mentioned but not deeply documented — its own README is authoritative.
+
+## Language and tooling limitations
+
+- **Ruby-only.** No FFI, no native extensions.
+- **macOS and Linux only in practice.** Windows is untested.
+- **CI runs on `ubuntu-latest` only** (currently Ubuntu 24.04).
+- **No `brakeman`.** Would be a reasonable addition given the admin surface; not wired today.
+
+## Recommendations
+
+Low effort, high value:
+1. **Wire `Config.monitor_timeout` into `MonitorClient`**, or remove the env var + field. Current state is cargo-cult.
+2. **Force-evaluate `HttpApp.configured_miners` in `Server#configure_http_app`** so miners.yml shape errors fail boot with exit 2, not HTTP 500 on first request.
+3. **Use `Config.session_secret` instead of reading `ENV['SESSION_SECRET']` inline in HttpApp's configure block.** Single source of truth.
+
+Medium effort, possibly worth it:
+4. Add `brakeman` to the CI lint job. The admin surface is the likely beneficiary.
+5. Add an OpenAPI spec + parity check (match monitor's pattern). Only if a third party consumes the API.
+6. Standardize config-error exit code to `78` across the three repos.
+
+Higher effort, defer:
+7. Persistent worker pool for dashboard snapshot fan-out. Only if load makes it necessary.
+8. Add an integration spec that boots the full `Server` and exercises real signal delivery. Subprocess orchestration is fiddly but doable.
+
+## How I validated
+
+- Read every file under `lib/`, `bin/`, `spec/support/`, `config/`, `.github/workflows/`, plus `Gemfile`, the gemspec, `Rakefile`, `.rubocop.yml`, `.rspec`, `Dockerfile`, `docker-compose.yml`, `config.ru`, `config/puma.rb`, `miners.yml.example`, README, CHANGELOG, MIGRATION.
+- Did not exhaustively read every `views/**/*.haml` file; sampled enough to understand the shape and confirm the claims about partial structure.
+- Did not read the integration specs' full bodies; enumerated them and spot-checked a few for shape.
+- Did not run the test suite as part of writing these docs. Claims like "passes cleanly" are based on reading the specs + CI config, not a pass/fail run (though `bundle exec rake` will be run before the commit that lands this doc set).
+- Did not verify every log event name by grepping — relied on the source-code context for each claim. If a new log event is added, it'll need to land in `interfaces.md` by hand.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,322 @@
+# Workflows
+
+Four runtime flows cover essentially everything: startup, dashboard rendering, admin/pool write operations, and graceful shutdown. Plus three dev workflows: running tests, regenerating screenshots, and refreshing monitor fixtures.
+
+## 1. Startup (`cgminer_manager run`)
+
+```mermaid
+sequenceDiagram
+    participant CLI as bin/cgminer_manager
+    participant Config
+    participant Logger
+    participant Server
+    participant HttpApp
+    participant Puma as Puma::Launcher
+    participant PumaT as Puma thread
+
+    CLI->>Config: Config.from_env
+    alt invalid env
+        Config--xCLI: raise ConfigError
+        CLI--xCLI: warn 'config error:', exit 2
+    end
+    CLI->>Logger: Logger.format= / level= from config
+    CLI->>Server: Server.new(config) and .run
+
+    Server->>Server: install_signal_handlers (trap INT/TERM → @stop)
+    Server->>HttpApp: set class attrs (monitor_url, miners_file, etc.)
+    Server->>HttpApp: reset_configured_miners!
+    Server->>Logger: Logger.info 'server.start'
+
+    Server->>Server: @booted = Queue.new
+    Server->>Puma: build launcher with raise_exception_on_sigterm false
+    Server->>Puma: launcher.events.on_booted { @booted << true }
+    Server->>PumaT: Thread.new { launcher.run }
+    PumaT->>PumaT: setup_signals (overwrites our INT/TERM!)
+    PumaT->>PumaT: bind listener on BIND:PORT
+    PumaT->>Server: @booted << true
+    Server->>Server: @booted.pop (wakes)
+    Server->>Server: install_signal_handlers again
+    Server->>Server: @stop.pop (block until signal)
+
+    Note over HttpApp,PumaT: app is now serving; goto request lifecycle
+```
+
+**Two signal-handler installs?** Yes. Puma's `setup_signals` synchronously overwrites SIGTERM/SIGINT handlers inside its thread. We install first so a signal arriving during boot lands in `@stop`, and install again after `@booted.pop` to reclaim those signals.
+
+**Two things can cause `cmd_run` to exit non-zero at boot:**
+- `ConfigError` — CLI rescues, exits 2.
+- `StandardError` escaping `Server#run` — propagates out, unhandled. Process dies and the supervisor restarts.
+
+## 2. Dashboard render (`GET /`)
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Puma
+    participant HttpApp
+    participant MC as MonitorClient
+    participant Workers as snapshot worker pool (thread_cap)
+    participant Monitor as cgminer_monitor
+    participant Adapter as SnapshotAdapter
+    participant HAML
+
+    Browser->>Puma: GET /
+    Puma->>HttpApp: dispatch to '/' route
+    HttpApp->>HttpApp: @request_started_at = Time.now
+
+    HttpApp->>HttpApp: build_dashboard_view_model
+    HttpApp->>MC: monitor_client.miners
+    MC->>Monitor: GET /v2/miners
+    alt monitor reachable
+        Monitor-->>MC: {miners: [...]}
+        MC->>Logger: 'monitor.call' url=/v2/miners status=200 duration_ms=...
+        MC-->>HttpApp: parsed miners
+        HttpApp->>HttpApp: fetch_snapshots_for(miners)
+
+        par per-miner parallel (up to pool_thread_cap)
+            HttpApp->>Workers: spawn worker with queue
+            Workers->>MC: summary, devices, pools, stats (four calls)
+            MC->>Monitor: four GETs per miner
+            Monitor-->>MC: four responses
+            MC-->>Workers: four parsed snapshots (each may be {error: ...} on rescue)
+            Workers-->>HttpApp: miner_id => {summary:, devices:, pools:, stats:}
+        end
+
+    else monitor down
+        MC--xHttpApp: MonitorError
+        HttpApp->>HttpApp: banner='data source unavailable'; miners=fallback from yml
+    end
+
+    HttpApp->>Adapter: SnapshotAdapter.build_miner_data(configured_miners, snapshots)
+    Adapter->>Adapter: per-type: sanitize keys, wrap in legacy [{type: inner}] shape
+    Adapter-->>HttpApp: @miner_data
+    HttpApp->>HttpApp: build_view_miner_pool(monitor_miners) → @miner_pool
+    HttpApp->>HAML: haml :'manager/index' with @miner_pool, @miner_data, @bad_chain_elements, @view
+    HAML->>HAML: render layout, _header, manager/index (Summary/Miner Pool/Admin tabs),
+    HAML-->>HttpApp: HTML
+    HttpApp->>Logger: after-filter: 'http.request' path=/ status=200 render_ms=...
+    HttpApp-->>Puma: 200 HTML
+    Puma-->>Browser: response
+```
+
+**Key observations:**
+- A dashboard render with 10 miners performs 1 + 10×4 = 41 HTTP calls to monitor. With `POOL_THREAD_CAP=8` (default), the 40 per-miner calls run in parallel batches of 8.
+- Each of the 40 per-miner calls independently catches `MonitorError` and turns it into `{error: "..."}`. A single bad tile doesn't fail the whole dashboard.
+- The top-level `build_dashboard_view_model` catch handles the "can't even enumerate miners" case — it falls back to `configured_miners` from `miners.yml` with no availability data and sets a banner.
+- `@miner_pool` drives the "Miner Pool" tab (availability status from monitor). `@miner_data` drives the "Summary" tab (per-miner hashrate and devices tables). Graph canvases on Summary pull their data from `/graph_data/:metric` via Chart.js after page load.
+
+## 3. Pool management flow (`POST /manager/manage_pools`)
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Puma
+    participant CSRF as ConditionalAuthenticityToken
+    participant HttpApp
+    participant PM as PoolManager
+    participant Workers as pool worker pool
+    participant Miners as cgminer instances
+
+    Browser->>Puma: POST /manager/manage_pools<br/>action_name=disable pool_index=1 authenticity_token=...
+    Puma->>CSRF: validate token (not admin path; AdminAuth skipped)
+    CSRF-->>HttpApp: dispatch
+
+    HttpApp->>HttpApp: action_name='disable', pool_index=1
+    HttpApp->>HttpApp: build_pool_manager_for_all
+    HttpApp->>PM: pm.disable_pool(pool_index: 1)
+
+    PM->>PM: run_each { |miner| run_verified(miner) { ... } }
+    par per-miner parallel (up to thread_cap)
+        Workers->>Miners: miner.disablepool(1)
+        Miners-->>Workers: response or raise
+
+        alt command succeeded
+            Workers->>Miners: miner.query(:pools)
+            Miners-->>Workers: pool list
+            Workers->>Workers: verify_pool_state: find pool 1, check STATUS == 'Disabled'
+            alt matches
+                Workers->>Miners: miner.query(:save)
+                Miners-->>Workers: save response or raise
+                Workers-->>PM: MinerEntry(command_status=:ok, save_status=:ok|:failed)
+            else mismatch
+                Workers-->>PM: MinerEntry(command_status=:indeterminate, save_status=:skipped)
+            end
+        else command failed
+            Workers-->>PM: MinerEntry(command_status=:failed, save_status=:skipped)
+        end
+    end
+
+    PM-->>HttpApp: PoolActionResult(entries)
+    HttpApp->>HAML: render_partial 'shared/manage_pools' with @result
+    HAML-->>HttpApp: HTML fragment
+    HttpApp-->>Puma: 200 HTML
+    Puma-->>Browser: response
+```
+
+**Key observations:**
+- Every verified pool op runs a post-write query to confirm state. `:indeterminate` is the third result state for "the RPC succeeded but the world isn't what we expect."
+- `save_status: :skipped` when the command step failed. No point saving an unchanged state.
+- `add_pool` is unverified (cgminer's response doesn't give the new pool index deterministically). `save_status` is always `:skipped` for unverified ops; callers run `save` explicitly.
+
+## 4. Admin flow (`POST /manager/admin/run`)
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Puma
+    participant AA as AdminAuth
+    participant CSRF as ConditionalAuthenticityToken
+    participant HttpApp
+    participant Cmdr as CgminerCommander
+    participant Workers as commander worker pool
+    participant Miners as cgminer instances
+
+    Browser->>Puma: POST /manager/admin/run<br/>command=stats args= scope=all<br/>authenticity_token=... (or Basic Auth)
+    Puma->>AA: path matches /(manager|miner/.../admin)/
+
+    alt Basic Auth configured
+        alt valid
+            AA->>AA: env['cgminer_manager.admin_authed'] = true
+            AA-->>CSRF: continue
+        else invalid
+            AA->>Logger: 'admin.auth_failed' reason=...
+            AA-->>Browser: 401 + WWW-Authenticate
+        end
+    else unconfigured
+        AA-->>CSRF: pass through (admin_authed = false)
+    end
+
+    CSRF->>CSRF: admin_authed? skip token : validate token
+    alt token missing/invalid (and no Basic Auth)
+        CSRF-->>Browser: 403 Forbidden
+    else ok
+        CSRF-->>HttpApp: dispatch
+    end
+
+    HttpApp->>HttpApp: before-filter: @request_id = SecureRandom.uuid
+    HttpApp->>HttpApp: validate command against ADMIN_RAW_COMMAND_PATTERN
+    alt pattern mismatch
+        HttpApp-->>Browser: 422 'invalid command: ...'
+    end
+    HttpApp->>HttpApp: scope check
+    alt SCOPE_RESTRICTED_VERBS + scope=all
+        HttpApp->>Logger: 'admin.scope_rejected' request_id=... command=... scope=all
+        HttpApp-->>Browser: 422 "command 'X' cannot target scope=all"
+    end
+    HttpApp->>HttpApp: build_commander_for_all or _for([scope])
+    HttpApp->>Logger: 'admin.raw_command' request_id=... command=... args=... scope=...
+
+    HttpApp->>Cmdr: cmd.raw!(command: ..., args: ...)
+    Cmdr->>Cmdr: fan_out_write { |m| m.query(verb, *positional) }
+    par per-miner parallel
+        Workers->>Miners: Miner.query(verb, *args)
+        Miners-->>Workers: response or raise
+        Workers->>Workers: wrap in FleetWriteEntry(ok/failed)
+    end
+    Cmdr-->>HttpApp: FleetWriteResult
+
+    HttpApp->>Logger: 'admin.result' request_id=... ok_count=N failed_count=M elapsed_ms=...
+    HttpApp->>HAML: render_admin_result(result)
+    HAML-->>HttpApp: HTML fragment (shared/_fleet_write)
+    HttpApp-->>Puma: 200 HTML
+    Puma-->>Browser: response
+```
+
+**Key observations:**
+- Entry (`admin.raw_command` or `admin.command`), rejection (`admin.scope_rejected`, `admin.auth_failed`), and exit (`admin.result`) events all share the same `request_id`. Grep logs by `request_id` to see one operation end-to-end.
+- Typed-allowlist admin routes (`/manager/admin/:command`) skip the `ADMIN_RAW_COMMAND_PATTERN` check (they use an enum match instead) and don't have `args` — they map directly to the commander's named methods.
+
+## 5. Graceful shutdown
+
+```mermaid
+flowchart TD
+    A[Signal or Puma crash] --> B[push to @stop Queue]
+    B --> C[Main thread unblocks from @stop.pop]
+    C --> D[Logger.info 'server.stopping']
+    D --> E[launcher.stop]
+    E --> F[puma_thread.join with shutdown_timeout]
+    F -->|clean| G[Logger.info 'server.stopped']
+    F -.timeout.- G
+    G --> H[Server#run returns 0]
+    H --> I[CLI#run returns 0]
+    I --> J[bin/cgminer_manager exits 0]
+
+    X[Puma thread raises internally] --> Y[rescue Exception]
+    Y --> Z[Logger.error 'puma.crash']
+    Z --> AA[push 'puma_crash' to @stop]
+    AA --> C
+```
+
+`puma_thread.join(shutdown_timeout)` returns nil if Puma hasn't stopped within `SHUTDOWN_TIMEOUT` seconds; we move on regardless. Worst case the supervisor sends SIGKILL and Puma dies mid-request.
+
+## 6. Local dev: running tests
+
+```sh
+bundle install
+bundle exec rake                                   # rubocop + rspec (full suite)
+bundle exec rspec --tag ~integration               # unit only (CI matrix runs this)
+bundle exec rspec --tag integration                # integration only
+bundle exec rspec path/to/spec.rb:123              # single example
+bundle exec rubocop                                # lint only
+bundle exec rubocop -A                             # lint + auto-correct
+```
+
+Coverage via SimpleCov, enforced at the default rake task (`ENFORCE_COVERAGE=1` implicit). Reports land in `coverage/`.
+
+No MongoDB or live cgminer required locally. Integration specs use:
+- **WebMock** to stub monitor's `/v2/*` (see `spec/support/monitor_stubs.rb`).
+- **FakeCgminer** TCP server (see `spec/support/fake_cgminer.rb`) for the few specs that exercise the cgminer side directly.
+
+## 7. Regenerating screenshots
+
+The `dev/screenshots/` harness is separate from the spec suite. It spins up a **real** cgminer fleet (6 TCP listeners at `127.0.0.1:40281..40286`), a fake monitor, and a manager process, then drives Playwright through the UI to capture PNGs for `public/screenshots/`.
+
+```sh
+cd dev/screenshots
+./boot.sh       # launches fake_cgminer_fleet, fake_monitor, manager
+# ... runs Playwright scenario.rb ...
+./teardown.sh   # cleanly shuts everything down
+```
+
+Logs land in `dev/screenshots/.run/*.log`. See `dev/screenshots/README.md` for details.
+
+## 8. Refreshing monitor fixtures
+
+`Rakefile` provides `rake spec:refresh_monitor_fixtures` for capturing live monitor responses into `spec/fixtures/monitor/*.json`:
+
+```sh
+CGMINER_MONITOR_URL=http://monitor.local:9292 \
+  CGMINER_FIXTURE_MINER_ID=192.168.1.10:4028 \
+  bundle exec rake spec:refresh_monitor_fixtures
+```
+
+Fetches `/v2/miners`, per-miner `{summary, devices, pools, stats}`, `/v2/graph_data/hashrate`, and `/v2/healthz` for the named miner. Writes them as `miners.json`, `summary.json`, etc. Useful after a monitor version bump when the envelope shape changes.
+
+## 9. Release
+
+Not automated. On a clean `master`:
+
+```sh
+bundle exec rake                                    # must pass
+# bump VERSION in lib/cgminer_manager/version.rb
+# update CHANGELOG.md (Keep-a-Changelog format)
+git commit -am "Release vX.Y.Z"
+gem build cgminer_manager.gemspec                   # produces cgminer_manager-X.Y.Z.gem
+gem push cgminer_manager-X.Y.Z.gem                  # requires 2FA (rubygems_mfa_required=true)
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+Docker image is not currently pushed by CI. If that changes later, it'd be a separate workflow triggered on tag push.
+
+## 10. Docker Compose dev stack
+
+`docker-compose.yml` wires manager, monitor, and Mongo together:
+
+```sh
+export SESSION_SECRET=$(ruby -rsecurerandom -e 'puts SecureRandom.hex(32)')
+cp config/miners.yml.example config/miners.yml
+docker compose up
+```
+
+Opens on `http://localhost:3000`. See README for Basic Auth env vars to add when exposing beyond localhost.


### PR DESCRIPTION
## Overview

Adds an AI-assistant knowledge base under `docs/` with a consolidated `AGENTS.md` at the repo root, and refreshes the README with an error taxonomy, CLI exit codes, and further-reading pointers — matching the docs treatment already shipped for the two sibling repos (`cgminer_api_client` and `cgminer_monitor`).

## Questions/Comments

The motivation is the same context rot tax that hit the two siblings: every new assistant session — and every new human contributor — re-learns the same handful of things from the source (why the signal handlers get re-installed after Puma's `setup_signals`, why `CgminerApiClient::Miner#to_s` is monkey-patched at the top of `http_app.rb`, why `SnapshotAdapter` preserves `%` where cgminer_monitor's Poller maps it to `_pct`, how the CSRF ↔ Basic Auth bypass interaction on admin routes actually works). Pinning those in versioned docs turns rediscovery into a lookup. The `docs/review_notes.md` at the bottom of the set deliberately records what I'm *not* sure about and flags small cleanup candidates (a `Config.monitor_timeout` field that isn't plumbed through to `MonitorClient`, an inline `ENV['SESSION_SECRET']` read in `HttpApp` that bypasses `Config.session_secret`, lazy validation of `miners.yml` shape that surfaces as HTTP 500 rather than CLI exit 2), so the docs stay honest.

The README refresh solves the same problem for operators: someone running this under systemd shouldn't have to read `cli.rb` to learn that exit 2 means config error, and someone writing a rescue block shouldn't have to read `errors.rb` to know what classes exist. The new Errors and Exit Codes subsection lives under the existing CLI section, and a Further Reading section at the bottom points at CHANGELOG, MIGRATION, AGENTS.md, docs/, and the two sibling repos (since operators often need to cross-reference them).

Pure docs — no code changes, nothing for CI to re-verify beyond the usual `bundle exec rake` which passes locally (148 examples, 0 failures, rubocop clean).