### PR TITLE
Add cross-repo e2e CI harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,7 @@ name: e2e
 
 on:
   schedule:
-    # Mondays 12:00 UTC — once a week, per the ideation brief.
-    - cron: '0 12 * * 1'
+    - cron: '0 12 * * 1'  # Mondays 12:00 UTC
   workflow_dispatch:
     inputs:
       monitor_ref:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: e2e
+
+on:
+  schedule:
+    # Mondays 12:00 UTC — once a week, per the ideation brief.
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+    inputs:
+      monitor_ref:
+        description: 'cgminer_monitor ref to build (branch, tag, or SHA)'
+        required: false
+        default: 'master'
+  repository_dispatch:
+    types: [cgminer-contract-change]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Clone cgminer_monitor
+        run: |
+          git clone --depth 1 \
+            --branch "${{ inputs.monitor_ref || 'master' }}" \
+            https://github.com/jramos/cgminer_monitor.git \
+            _e2e_build/cgminer_monitor
+
+      - name: Seed miners.yml
+        run: cp test/e2e/miners.yml config/miners.yml
+
+      - name: Generate admin password
+        run: echo "CGMINER_MANAGER_ADMIN_PASSWORD=$(openssl rand -hex 16)" >> "$GITHUB_ENV"
+
+      - name: Compose up
+        env:
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.e2e.yml \
+            up -d --build --wait --wait-timeout 300
+
+      - name: Smoke test
+        env:
+          ADMIN_USER: admin
+          ADMIN_PASSWORD: ${{ env.CGMINER_MANAGER_ADMIN_PASSWORD }}
+        run: bash test/e2e/smoke.sh
+
+      - name: Dump compose state on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml ps
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config/miners.yml
 config/mongoid.yml
 ._*
 /coverage
+/_e2e_build
 
 # Override the global `docs/*` ignore so the AI-assistant docs in docs/*.md
 # track with the repo. The global rule still covers anything non-Markdown

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -70,15 +70,12 @@ services:
     # Uses a non-default port for the same reason manager does (see below).
     ports:
       - "19292:9292"
-    # Invoke via `bundle exec ruby bin/cgminer_monitor` rather than the image's
-    # default `bundle exec cgminer_monitor` entrypoint: monitor's Dockerfile
-    # uses `gemspec` in its Gemfile without generating binstubs, so bundler
-    # can't resolve the `cgminer_monitor` executable at runtime. Calling the
-    # script directly sidesteps the bundler resolution failure. Remove this
-    # override once monitor's Dockerfile ships binstubs.
+    # Run migrate then the server. Mirrors monitor's own docker-compose.yml:
+    # the image's ENTRYPOINT is exec-form `bundle exec cgminer_monitor`, so an
+    # override to chain verbs must also replace the entrypoint.
     entrypoint: ["sh", "-c"]
     command:
-      - "bundle exec ruby bin/cgminer_monitor migrate && bundle exec ruby bin/cgminer_monitor run"
+      - "cgminer_monitor migrate && cgminer_monitor run"
     healthcheck:
       test:
         - "CMD"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,119 @@
+# docker-compose.e2e.yml — cross-repo end-to-end test harness.
+#
+# Layered over docker-compose.yml:
+#   docker compose -f docker-compose.yml -f docker-compose.e2e.yml up -d --wait
+#
+# Prerequisites before `up`:
+#   1. `_e2e_build/cgminer_monitor/` must exist (CI clones monitor into it;
+#      for local use, `git clone https://github.com/jramos/cgminer_monitor.git
+#      _e2e_build/cgminer_monitor`).
+#   2. `config/miners.yml` must match `test/e2e/miners.yml` (CI copies it;
+#      for local use, `cp test/e2e/miners.yml config/miners.yml`).
+#   3. Env: `SESSION_SECRET`, `CGMINER_MANAGER_ADMIN_PASSWORD`.
+#
+# Adds three FakeCgminer containers reachable as `fake1`/`fake2`/`fake3` on the
+# compose network, builds monitor from source, and wires healthchecks across
+# the whole graph so `--wait` blocks until everything is actually healthy.
+
+services:
+  mongo:
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "mongosh --quiet --eval 'db.adminCommand({ping:1}).ok' | grep -q 1"
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  fake1: &fake
+    image: ruby:3.4-slim
+    working_dir: /app
+    volumes:
+      - ./spec/support:/app/spec/support:ro
+    command:
+      - "ruby"
+      - "-r"
+      - "/app/spec/support/cgminer_fixtures.rb"
+      - "-r"
+      - "/app/spec/support/fake_cgminer.rb"
+      - "-e"
+      - "FakeCgminer.with(port: 4028, host: '0.0.0.0') { |p| puts p; sleep }"
+    healthcheck:
+      test:
+        - "CMD"
+        - "ruby"
+        - "-rsocket"
+        - "-e"
+        - "TCPSocket.new('127.0.0.1', 4028).close"
+      interval: 3s
+      timeout: 5s
+      retries: 20
+
+  fake2: *fake
+  fake3: *fake
+
+  monitor:
+    build:
+      context: ./_e2e_build/cgminer_monitor
+    depends_on: !override
+      mongo:
+        condition: service_healthy
+      fake1:
+        condition: service_healthy
+      fake2:
+        condition: service_healthy
+      fake3:
+        condition: service_healthy
+    environment:
+      CGMINER_MONITOR_INTERVAL: "5"
+    # Publish monitor on the host so smoke.sh can assert against /v2/* directly.
+    # Uses a non-default port for the same reason manager does (see below).
+    ports:
+      - "19292:9292"
+    # Invoke via `bundle exec ruby bin/cgminer_monitor` rather than the image's
+    # default `bundle exec cgminer_monitor` entrypoint: monitor's Dockerfile
+    # uses `gemspec` in its Gemfile without generating binstubs, so bundler
+    # can't resolve the `cgminer_monitor` executable at runtime. Calling the
+    # script directly sidesteps the bundler resolution failure. Remove this
+    # override once monitor's Dockerfile ships binstubs.
+    entrypoint: ["sh", "-c"]
+    command:
+      - "bundle exec ruby bin/cgminer_monitor migrate && bundle exec ruby bin/cgminer_monitor run"
+    healthcheck:
+      test:
+        - "CMD"
+        - "ruby"
+        - "-rnet/http"
+        - "-rjson"
+        - "-e"
+        - "h=JSON.parse(Net::HTTP.get(URI('http://127.0.0.1:9292/v2/healthz'))); exit(h['status']=='healthy' ? 0 : 1)"
+      interval: 5s
+      timeout: 5s
+      retries: 36
+      start_period: 10s
+
+  manager:
+    depends_on: !override
+      monitor:
+        condition: service_healthy
+    # Publish on a distinct host port to avoid clashing with anything the
+    # developer has bound to :3000 (a Rails dev server, etc.) on the machine
+    # running the e2e stack. CI-side or inside the compose network, nothing
+    # changes — the smoke.sh script reads MANAGER_URL to stay in sync.
+    ports: !override
+      - "13000:3000"
+    environment:
+      CGMINER_MANAGER_ADMIN_USER: "admin"
+      CGMINER_MANAGER_ADMIN_PASSWORD: "${CGMINER_MANAGER_ADMIN_PASSWORD:?set CGMINER_MANAGER_ADMIN_PASSWORD}"
+    healthcheck:
+      test:
+        - "CMD"
+        - "ruby"
+        - "-rnet/http"
+        - "-rjson"
+        - "-e"
+        - "h=JSON.parse(Net::HTTP.get(URI('http://127.0.0.1:3000/healthz'))); exit(h['ok']==true ? 0 : 1)"
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 5s

--- a/spec/support/fake_cgminer.rb
+++ b/spec/support/fake_cgminer.rb
@@ -33,10 +33,10 @@ require 'socket'
 class FakeCgminer
   attr_reader :port
 
-  def initialize(responses: CgminerFixtures::DEFAULT, port: 0, on_request: nil)
+  def initialize(responses: CgminerFixtures::DEFAULT, port: 0, host: '127.0.0.1', on_request: nil)
     @responses = responses
     @on_request = on_request
-    @server = TCPServer.new('127.0.0.1', port)
+    @server = TCPServer.new(host, port)
     @port = @server.addr[1]
   end
 

--- a/test/e2e/miners.yml
+++ b/test/e2e/miners.yml
@@ -1,0 +1,6 @@
+- host: fake1
+  port: 4028
+- host: fake2
+  port: 4028
+- host: fake3
+  port: 4028

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Cross-repo e2e smoke test — assumes the full stack (fake1-3, mongo, monitor,
+# manager) is already up and reachable via docker-compose on localhost.
+#
+# Env inputs:
+#   ADMIN_USER, ADMIN_PASSWORD — Basic Auth credentials matching the manager
+#   service's CGMINER_MANAGER_ADMIN_USER / CGMINER_MANAGER_ADMIN_PASSWORD.
+#
+# Exits non-zero on the first failed assertion. Callers (CI, local) are
+# responsible for dumping docker-compose logs on failure.
+
+set -euo pipefail
+
+MANAGER="${MANAGER_URL:-http://localhost:13000}"
+MONITOR="${MONITOR_URL:-http://localhost:19292}"
+
+: "${ADMIN_USER:?ADMIN_USER must be set}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# --- Phase 1: AdminAuth gate is actually engaged -----------------------------
+# An unauthenticated POST to an admin route must be rejected. If this passes
+# with 200, the admin credentials weren't applied and every subsequent admin
+# assertion is meaningless.
+echo "== Phase 1: AdminAuth gate =="
+code=$(curl -sS -o /dev/null -w "%{http_code}" -X POST "$MANAGER/manager/admin/version")
+[[ "$code" == "401" ]] || fail "unauthenticated POST /manager/admin/version returned $code (expected 401)"
+
+# --- Phase 2: monitor contract ----------------------------------------------
+echo "== Phase 2: monitor contract =="
+
+# /v2/healthz — poll until status is "healthy" (not "starting", not "degraded").
+# Compose's own healthcheck already gates monitor to healthy before manager
+# starts, but we re-check here against the external API in case the compose
+# gate used a different probe.
+status=""
+for _ in $(seq 1 30); do
+  status=$(curl -sS "$MONITOR/v2/healthz" | jq -r '.status')
+  [[ "$status" == "healthy" ]] && break
+  sleep 2
+done
+[[ "$status" == "healthy" ]] || fail "monitor /v2/healthz status=$status (expected healthy)"
+
+# /v2/miners — expect exactly 3 miners, all available.
+miners_json=$(curl -sS "$MONITOR/v2/miners")
+count=$(echo "$miners_json" | jq '.miners | length')
+[[ "$count" == "3" ]] || fail "expected 3 miners, got $count -- $miners_json"
+all_avail=$(echo "$miners_json" | jq '[.miners[].available] | all')
+[[ "$all_avail" == "true" ]] || fail "not all miners available -- $miners_json"
+
+# --- Phase 3: manager contract ----------------------------------------------
+echo "== Phase 3: manager contract =="
+
+# /healthz — manager's own readiness (checks miners.yml + monitor reachable).
+health=$(curl -sS "$MANAGER/healthz" | jq -r '.ok')
+[[ "$health" == "true" ]] || fail "manager /healthz ok=$health (expected true)"
+
+# Dashboard index must not explode. Content-matching is deliberately avoided
+# (HTML escaping, label formatting, and template structure are too volatile
+# to assert on); a 200 is enough to catch "MonitorClient contract drifted and
+# the view model crashes."
+code=$(curl -sS -o /dev/null -w "%{http_code}" "$MANAGER/")
+[[ "$code" == "200" ]] || fail "GET / returned $code"
+
+# Miner detail page. The colon in the miner id is URL-encoded because the
+# route handler calls CGI.unescape(params[:miner_id]) (http_app.rb).
+code=$(curl -sS -o /dev/null -w "%{http_code}" "$MANAGER/miner/fake1%3A4028")
+[[ "$code" == "200" ]] || fail "GET /miner/fake1%3A4028 returned $code"
+
+# /api/v1/ping.json — response shape is {timestamp, available_miners,
+# unavailable_miners} with integer counts (http_app.rb:699-704).
+ping_json=$(curl -sS "$MANAGER/api/v1/ping.json")
+avail=$(echo "$ping_json" | jq '.available_miners')
+unavail=$(echo "$ping_json" | jq '.unavailable_miners')
+[[ "$avail" == "3" && "$unavail" == "0" ]] \
+  || fail "ping: available=$avail unavailable=$unavail (expected 3/0) -- $ping_json"
+
+# Admin POSTs — Basic Auth bypasses CSRF (admin_auth.rb), so no token scrape
+# needed. Only read-only verbs from ALLOWED_ADMIN_QUERIES are exercised.
+for verb in version stats; do
+  code=$(curl -sS -o /dev/null -w "%{http_code}" \
+    -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+    -X POST "$MANAGER/manager/admin/$verb")
+  [[ "$code" == "200" ]] || fail "POST /manager/admin/$verb returned $code"
+done
+
+echo "OK: all smoke assertions passed"


### PR DESCRIPTION
## Summary

Adds a weekly GitHub Actions job that boots the full three-gem stack (FakeCgminer × 3 → cgminer_monitor → cgminer_manager) via docker-compose and asserts the contract holds end-to-end.

- `spec/support/fake_cgminer.rb` gains a backward-compatible `host:` kwarg so fake miners can bind to `0.0.0.0` for cross-container reachability (default stays `127.0.0.1`).
- `docker-compose.e2e.yml` layers over the base compose: adds three `fake*` services, builds monitor from `./_e2e_build/cgminer_monitor/` (populated by the workflow), wires healthchecks across the whole graph so `compose up --wait` is meaningful, and publishes non-default host ports (13000/19292) to avoid clashing with a developer's local Rails/Puma.
- `test/e2e/smoke.sh` exercises the contract with curl+jq: AdminAuth gate (unauth POST returns 401), monitor `/v2/healthz` reaches `healthy`, `/v2/miners` shape, manager `/healthz`, dashboard + miner detail HTML, `/api/v1/ping.json` counts, and Basic-Auth'd admin POSTs (`version`, `stats`).
- `.github/workflows/e2e.yml` runs it Mondays 12:00 UTC, plus `workflow_dispatch` (with an optional `monitor_ref` input to pin monitor) and `repository_dispatch(cgminer-contract-change)` for sibling-repo triggers.

Sibling fixes landed in `cgminer_monitor` (commits `2585831` + `68975bb`) while implementing this: the Docker build now generates binstubs so `bundle exec cgminer_monitor` resolves, and its own compose overrides the ENTRYPOINT so the migrate-then-run chain actually executes. The final manager commit drops the temporary `bundle exec ruby bin/...` workaround.

## Test plan

- [x] `rspec spec/integration/{admin,pool_management}_spec.rb` — 19/19 pass after the `FakeCgminer` change
- [x] `rubocop spec/support/fake_cgminer.rb` — clean
- [x] `shellcheck test/e2e/smoke.sh` — clean
- [x] `docker compose -f docker-compose.yml -f docker-compose.e2e.yml config` — merges cleanly
- [x] Full stack up + `bash test/e2e/smoke.sh` — all assertions pass locally against a fresh monitor build
- [ ] First scheduled (or `gh workflow run e2e.yml`) invocation is green on GitHub Actions
- [ ] Negative-path validation: deliberately rename a `/v2/miners` field in monitor, rebuild, re-run — smoke.sh should fail red