### PR TITLE
Publish multi-arch container images on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release — publish container image
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: >-
+          Tag applied to the dispatched image. If it parses as semver
+          (e.g. "1.2.3"), the full tag family (1.2.3 / 1.2 / 1) is
+          published. Otherwise it becomes a single literal tag
+          (default "edge").
+        required: false
+        default: 'edge'
+
+permissions:
+  contents: read
+  packages: write
+  # Required by docker/build-push-action provenance + sbom attestations.
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Derive platform-pair slug (for artifact names)
+        id: slug
+        run: echo "pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract OCI labels (shared across archs)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          provenance: true
+          sbom: true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.slug.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tag rules:
+      #   - {{version}}: always — v1.3.0 → 1.3.0; v1.4.0-rc1 → 1.4.0-rc1.
+      #   - {{major}}.{{minor}} / {{major}}: only for non-prerelease tags,
+      #     so a "-rc1" tag can't steal the 1.4 / 1 stable-channel pointers.
+      #   - latest: only for non-prerelease tag pushes on the default branch.
+      #   - workflow_dispatch: input.image_tag becomes a literal tag; if it
+      #     parses as semver, metadata-action also emits the {{version}}
+      #     form. Anything else is a raw tag.
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
+            type=semver,pattern={{version}},value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create multi-arch manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<<"$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect published manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- **CI publishes multi-arch container images on `v*` tag push.** New
+  `.github/workflows/release.yml` builds `linux/amd64` + `linux/arm64`
+  images on native GitHub-hosted runners and pushes to
+  `ghcr.io/jramos/cgminer_manager` with semver-derived tags
+  (`1.2.3` / `1.2` / `1` / `latest`, prerelease-safe) plus SLSA
+  provenance and CycloneDX SBOM attestations. A `workflow_dispatch`
+  entry point runs ad-hoc builds with a user-supplied tag
+  (default `edge`) for smoke tests.
+
 ### Changed
 - **Thread-cap fan-out extracted to `CgminerManager::ThreadedFanOut.map`.**
   The Queue + fixed-worker + Mutex pattern previously duplicated across

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Screenshots are generated from a scripted harness in `dev/screenshots/` — see 
 
 ## Quick start (Docker)
 
+Multi-arch images (`linux/amd64` + `linux/arm64`) are published from CI
+to GHCR on every `v*` tag push:
+
+```bash
+docker pull ghcr.io/jramos/cgminer_manager:latest
+# or pin to a specific release:
+docker pull ghcr.io/jramos/cgminer_manager:1.3
+```
+
+Run with the provided compose stack:
+
 ```bash
 export SESSION_SECRET=$(ruby -rsecurerandom -e 'puts SecureRandom.hex(32)')
 cp config/miners.yml.example config/miners.yml


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` — identical to the one landing in \`cgminer_monitor\` PR #4. On every \`v*\` tag push (and via \`workflow_dispatch\`), builds \`linux/amd64\` + \`linux/arm64\` on native runners and publishes to \`ghcr.io/jramos/cgminer_manager\`.

## Design

- **Matrix on \`ubuntu-24.04\` + \`ubuntu-24.04-arm\`**, digest-only per-arch push, \`merge\` job creates the tagged multi-arch manifest. Wall-clock ~7-8 min; partial-failure safe.
- **Prerelease-safe tags**: \`{{version}}\` always; \`{{major}}.{{minor}}\` / \`{{major}}\` / \`latest\` only for non-prerelease tags.
- **Provenance + SBOM** attached to each image.
- **\`GITHUB_TOKEN\` only** — no new secrets.

## Test plan

- [ ] Merge to develop, fold to master, cut \`v1.3.1\` tag.
- [ ] Watch the tag-triggered run publish \`:1.3.1\` / \`:1.3\` / \`:1\` / \`:latest\`.
- [ ] Flip package visibility to public (one-time).
- [ ] Anonymous \`docker pull ghcr.io/jramos/cgminer_manager:latest\` succeeds.

Ideation item 3.1.