### PR TITLE
feat: hot-reload miners.yml via SIGHUP (+ reload CLI verb)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,10 +33,14 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   # HttpApp is still the fattest file post-split — 14 routes + error
   # handlers + HTML/display helpers. PoolManager's body is mostly
-  # threaded fan-out boilerplate that splitting would obscure.
+  # threaded fan-out boilerplate that splitting would obscure. CLI
+  # now hosts run/doctor/reload/version plus five posture-report
+  # helpers; extracting a Doctor service would hide the linear
+  # one-screen read of what each verb does.
   Exclude:
     - 'lib/cgminer_manager/http_app.rb'
     - 'lib/cgminer_manager/pool_manager.rb'
+    - 'lib/cgminer_manager/cli.rb'
 
 Metrics/AbcSize:
   Max: 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## [Unreleased]
 
 ### Added
+- **`miners.yml` hot reload via SIGHUP.** Add, remove, or re-label a
+  miner without restarting. The Server traps SIGHUP, atomically
+  re-parses `settings.miners_file`, and swaps `settings.configured_miners`
+  — `PoolManager`, `CgminerCommander`, and the dashboard/per-miner
+  routes all read the new list on the next request. Parse or
+  validation failures log `event=reload.failed` and keep the previous
+  list so a typo can't crash a running server. New CLI verb
+  `bin/cgminer_manager reload` reads `CGMINER_MANAGER_PID_FILE`,
+  dry-run-parses miners.yml locally (surfacing typos at exit 2 before
+  signaling), and sends SIGHUP; `doctor` reports the PID file's
+  posture (`not configured` / `OK (pid N)` / `STALE` / `missing`).
 - **CI publishes multi-arch container images on `v*` tag push.** New
   `.github/workflows/release.yml` builds `linux/amd64` + `linux/arm64`
   images on native GitHub-hosted runners and pushes to

--- a/README.md
+++ b/README.md
@@ -96,12 +96,24 @@ All settings come from environment variables.
 | `LOG_LEVEL` | | `info` | `debug`, `info`, `warn`, `error` |
 | `STALE_THRESHOLD_SECONDS` | | `300` | Tile "updated Xm ago" warning threshold |
 | `SHUTDOWN_TIMEOUT` | | `10` | Seconds to wait for Puma to stop |
+| `CGMINER_MANAGER_PID_FILE` | | unset | Path where `run` writes the server PID on boot and unlinks on shutdown. Required for `bin/cgminer_manager reload`; operators who prefer can still `kill -HUP <pid>` directly. |
 
 ## CLI
 
 - `bin/cgminer_manager run` — start the server.
 - `bin/cgminer_manager doctor` — verify `miners.yml`, cgminer reachability, and monitor `/v2/miners`.
+- `bin/cgminer_manager reload` — dry-run-parse `miners.yml`, then SIGHUP the running server (requires `CGMINER_MANAGER_PID_FILE`).
 - `bin/cgminer_manager version` — print version.
+
+### Hot reload
+
+`miners.yml` is hot-reloadable — add, remove, or re-label a miner, then
+either `kill -HUP $(cat $CGMINER_MANAGER_PID_FILE)` or
+`bin/cgminer_manager reload`. The server logs `event=reload.ok` on
+success or `event=reload.failed` (and keeps the old list) if the new
+file fails to parse. Only `settings.configured_miners` reloads; other
+`Config` fields (`CGMINER_MONITOR_URL`, `SESSION_SECRET`, log level,
+etc.) still require a full restart to change.
 
 ### Errors and Exit Codes
 

--- a/lib/cgminer_manager/cli.rb
+++ b/lib/cgminer_manager/cli.rb
@@ -11,10 +11,11 @@ module CgminerManager
       case verb
       when 'run'     then cmd_run
       when 'doctor'  then cmd_doctor
+      when 'reload'  then cmd_reload
       when 'version' then cmd_version
       else
         warn "unknown verb: #{verb.inspect}"
-        warn 'usage: cgminer_manager {run|doctor|version}'
+        warn 'usage: cgminer_manager {run|doctor|reload|version}'
         64
       end
     rescue ConfigError => e
@@ -66,6 +67,39 @@ module CgminerManager
     def cmd_version
       puts CgminerManager::VERSION
       0
+    end
+
+    # Dry-run-parses miners.yml locally so typos surface at the
+    # operator's terminal (exit 2 via ConfigError rescue above) instead
+    # of in the server's logs, then sends SIGHUP to the PID recorded
+    # by a running `cgminer_manager run`. Operators can also skip this
+    # verb and `kill -HUP <pid>` directly.
+    def cmd_reload
+      config   = Config.from_env
+      pid_path = config.pid_file
+      if pid_path.nil? || pid_path.empty?
+        raise ConfigError,
+              'CGMINER_MANAGER_PID_FILE not set; cannot locate running server'
+      end
+
+      begin
+        HttpApp.parse_miners_file(config.miners_file)
+      rescue Psych::SyntaxError => e
+        raise ConfigError, "miners_file is not valid YAML: #{e.message}"
+      end
+
+      pid = Integer(File.read(pid_path).strip)
+      Process.kill(0, pid) # probe alive; raises Errno::ESRCH if dead
+      Process.kill('HUP', pid)
+      puts "SIGHUP sent to pid #{pid}; check server logs for reload.ok"
+      0
+    rescue Errno::ENOENT
+      warn "pid file not found: #{pid_path} " \
+           '(server may still be starting — pid file is written after Puma boots)'
+      1
+    rescue Errno::ESRCH
+      warn "stale pid file (pid not running): #{pid_path}"
+      1
     end
 
     def check_monitor(config, failures)

--- a/lib/cgminer_manager/cli.rb
+++ b/lib/cgminer_manager/cli.rb
@@ -101,7 +101,7 @@ module CgminerManager
     # of in the server's logs, then sends SIGHUP to the PID recorded
     # by a running `cgminer_manager run`. Operators can also skip this
     # verb and `kill -HUP <pid>` directly.
-    def cmd_reload
+    def cmd_reload # rubocop:disable Metrics/MethodLength
       config   = Config.from_env
       pid_path = config.pid_file
       if pid_path.nil? || pid_path.empty?
@@ -126,6 +126,9 @@ module CgminerManager
       1
     rescue Errno::ESRCH
       warn "stale pid file (pid not running): #{pid_path}"
+      1
+    rescue ArgumentError
+      warn "pid file is not an integer: #{pid_path}"
       1
     end
 

--- a/lib/cgminer_manager/cli.rb
+++ b/lib/cgminer_manager/cli.rb
@@ -39,6 +39,7 @@ module CgminerManager
       monitor_miners = check_monitor(config, failures)
       check_miners(config, monitor_miners, failures)
       report_admin_auth_posture(failures)
+      report_pid_file_posture(failures)
 
       if failures.empty?
         puts 'doctor: all checks passed'
@@ -62,6 +63,32 @@ module CgminerManager
       else
         failures << 'admin auth misconfigured: no credentials and no escape hatch'
       end
+    end
+
+    # Same audit-honest treatment as admin-auth posture: explicitly
+    # report whether the PID file exists and whether the recorded PID
+    # is alive, so an operator reading `doctor` output knows whether
+    # `cgminer_manager reload` will work. A configured-but-missing or
+    # stale file is a failure (exit 1).
+    def report_pid_file_posture(failures)
+      path = ENV.fetch('CGMINER_MANAGER_PID_FILE', nil)
+      if path.nil? || path.empty?
+        puts '  pid file: not configured'
+        return
+      end
+
+      unless File.exist?(path)
+        failures << "pid file configured but missing: #{path}"
+        return
+      end
+
+      pid = Integer(File.read(path).strip)
+      Process.kill(0, pid)
+      puts "  pid file: OK (pid #{pid})"
+    rescue ArgumentError
+      failures << "pid file is not an integer: #{path}"
+    rescue Errno::ESRCH
+      failures << "pid file: STALE (pid in #{path} not running)"
     end
 
     def cmd_version

--- a/lib/cgminer_manager/cli.rb
+++ b/lib/cgminer_manager/cli.rb
@@ -89,6 +89,8 @@ module CgminerManager
       failures << "pid file is not an integer: #{path}"
     rescue Errno::ESRCH
       failures << "pid file: STALE (pid in #{path} not running)"
+    rescue Errno::EPERM
+      failures << "pid file: pid in #{path} exists but is not owned by us"
     end
 
     def cmd_version
@@ -126,6 +128,10 @@ module CgminerManager
       1
     rescue Errno::ESRCH
       warn "stale pid file (pid not running): #{pid_path}"
+      1
+    rescue Errno::EPERM
+      warn "pid #{pid} exists but is not owned by us " \
+           "(stale pid file from a different user? #{pid_path})"
       1
     rescue ArgumentError
       warn "pid file is not an integer: #{pid_path}"

--- a/lib/cgminer_manager/config.rb
+++ b/lib/cgminer_manager/config.rb
@@ -14,6 +14,7 @@ module CgminerManager
     :shutdown_timeout,
     :monitor_timeout,
     :pool_thread_cap,
+    :pid_file,
     :rack_env
   ) do
     def validate!
@@ -50,6 +51,7 @@ module CgminerManager
         shutdown_timeout: parse_int(env, 'SHUTDOWN_TIMEOUT', '10'),
         monitor_timeout: parse_int(env, 'MONITOR_TIMEOUT_MS', '2000'),
         pool_thread_cap: parse_int(env, 'POOL_THREAD_CAP', '8'),
+        pid_file: env['CGMINER_MANAGER_PID_FILE'],
         rack_env: rack_env
       ).validate!
     end

--- a/lib/cgminer_manager/http_app.rb
+++ b/lib/cgminer_manager/http_app.rb
@@ -58,6 +58,23 @@ module CgminerManager
     end
     private_class_method :validate_miners_shape!
 
+    # Re-parses `settings.miners_file` and atomically swaps
+    # `settings.configured_miners`. Returns the new miner count on
+    # success, nil on parse/validation/IO failure — on failure the
+    # old setting is untouched so in-flight readers never see a torn
+    # state. Callers distinguish success from no-op by the return
+    # value.
+    def self.reload_miners!
+      path = settings.miners_file
+      new_miners = parse_miners_file(path)
+      set :configured_miners, new_miners
+      new_miners.size
+    rescue ConfigError, Errno::ENOENT, Psych::SyntaxError => e
+      Logger.warn(event: 'reload.failed',
+                  error: e.class.to_s, message: e.message)
+      nil
+    end
+
     # Spec harness. Preserves the existing public signature so no spec
     # file needs to change. Eagerly parses miners_file into the setting
     # so specs don't rely on a later lazy load.

--- a/lib/cgminer_manager/server.rb
+++ b/lib/cgminer_manager/server.rb
@@ -70,7 +70,8 @@ module CgminerManager
       Thread.new do
         launcher.run
       rescue Exception => e # rubocop:disable Lint/RescueException
-        Logger.error(event: 'puma.crash', error: e.class.to_s, message: e.message)
+        Logger.error(event: 'puma.crash', error: e.class.to_s,
+                     message: e.message, backtrace: e.backtrace&.first(10))
         @booted << true # unblock main if we died before booting
         @signals << :stop
       end

--- a/lib/cgminer_manager/server.rb
+++ b/lib/cgminer_manager/server.rb
@@ -8,8 +8,8 @@ require 'rack'
 module CgminerManager
   class Server
     def initialize(config)
-      @config = config
-      @stop   = Queue.new
+      @config  = config
+      @signals = Queue.new
     end
 
     def run
@@ -19,24 +19,30 @@ module CgminerManager
                   bind: @config.bind, port: @config.port)
 
       @booted = Queue.new
-      launcher = build_puma_launcher
+      launcher    = build_puma_launcher
       puma_thread = start_puma_thread(launcher)
 
       # Puma's setup_signals runs on its thread during launcher.run and
-      # overwrites any SIGTERM/SIGINT traps we installed earlier. Wait for
-      # Puma to finish booting (signals already installed, listener already
-      # bound) before reinstalling ours so signals land back in our @stop
-      # queue.
+      # overwrites any traps we installed earlier. Wait for Puma to
+      # finish booting (signals already installed, listener bound)
+      # before reinstalling ours so signals land back in our @signals
+      # queue. Covers SIGHUP too — Puma's default HUP handler calls
+      # stop() when stdout_redirect is unset, which would shut us down
+      # instead of triggering a reload.
       @booted.pop
       install_signal_handlers
 
-      signal = @stop.pop
-      Logger.info(event: 'server.stopping', signal: signal)
+      write_pid_file
+
+      dispatch_signals_until_stop
+      Logger.info(event: 'server.stopping')
 
       launcher.stop
       puma_thread.join(@config.shutdown_timeout)
       Logger.info(event: 'server.stopped')
       0
+    ensure
+      unlink_pid_file
     end
 
     private
@@ -66,12 +72,47 @@ module CgminerManager
       rescue Exception => e # rubocop:disable Lint/RescueException
         Logger.error(event: 'puma.crash', error: e.class.to_s, message: e.message)
         @booted << true # unblock main if we died before booting
-        @stop << 'puma_crash'
+        @signals << :stop
       end
     end
 
     def install_signal_handlers
-      %w[INT TERM].each { |s| trap(s) { @stop << s } }
+      Signal.trap('INT')  { @signals << :stop }
+      Signal.trap('TERM') { @signals << :stop }
+      Signal.trap('HUP')  { @signals << :reload }
+    end
+
+    def dispatch_signals_until_stop
+      loop do
+        case @signals.pop
+        when :reload then perform_reload
+        when :stop   then break
+        end
+      end
+    end
+
+    # Single-swap reload: HttpApp holds the only live reference to the
+    # miner list. No partial-failure window — either the new list
+    # parses and lands, or it doesn't and the old list stays.
+    def perform_reload
+      Logger.info(event: 'reload.signal_received')
+      count = HttpApp.reload_miners!
+      Logger.info(event: 'reload.ok', miners: count) if count
+    end
+
+    def write_pid_file
+      return unless @config.pid_file
+
+      File.write(@config.pid_file, "#{Process.pid}\n")
+      Logger.info(event: 'server.pid_file_written', path: @config.pid_file)
+    end
+
+    def unlink_pid_file
+      return unless @config.pid_file
+
+      File.unlink(@config.pid_file)
+    rescue Errno::ENOENT
+      # already gone — shutdown raced with external cleanup; fine
     end
 
     def build_puma_launcher

--- a/spec/cgminer_manager/cli_reload_spec.rb
+++ b/spec/cgminer_manager/cli_reload_spec.rb
@@ -55,4 +55,10 @@ RSpec.describe CgminerManager::CLI, 'reload' do # rubocop:disable RSpec/Describe
     expect { expect(described_class.run(['reload'])).to eq(2) }
       .to output(/CGMINER_MANAGER_PID_FILE not set/).to_stderr
   end
+
+  it 'returns 1 with a clear message when the pid file contains garbage' do
+    File.write(pid_path, "not-a-number\n")
+    expect { expect(described_class.run(['reload'])).to eq(1) }
+      .to output(/pid file is not an integer/).to_stderr
+  end
 end

--- a/spec/cgminer_manager/cli_reload_spec.rb
+++ b/spec/cgminer_manager/cli_reload_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe CgminerManager::CLI, 'reload' do # rubocop:disable RSpec/DescribeMethod
+  let(:dir)         { Dir.mktmpdir }
+  let(:miners_path) { File.join(dir, 'miners.yml') }
+  let(:pid_path)    { File.join(dir, 'cgminer_manager.pid') }
+
+  before do
+    File.write(miners_path, "- host: 10.0.0.1\n  port: 4028\n")
+    stub_const('ENV', ENV.to_h.merge(
+                        'CGMINER_MONITOR_URL' => 'http://example',
+                        'MINERS_FILE' => miners_path,
+                        'CGMINER_MANAGER_PID_FILE' => pid_path,
+                        'CGMINER_MANAGER_ADMIN_AUTH' => 'off',
+                        'SESSION_SECRET' => 'x' * 64
+                      ))
+  end
+
+  after { FileUtils.rm_rf(dir) }
+
+  it 'sends SIGHUP to the recorded pid and returns 0' do
+    File.write(pid_path, "#{Process.pid}\n")
+    allow(Process).to receive(:kill).with(0, Process.pid).and_return(1)
+    allow(Process).to receive(:kill).with('HUP', Process.pid).and_return(1)
+
+    expect { expect(described_class.run(['reload'])).to eq(0) }
+      .to output(/SIGHUP sent to pid/).to_stdout
+    expect(Process).to have_received(:kill).with('HUP', Process.pid)
+  end
+
+  it 'returns 1 when the pid file is missing' do
+    expect { expect(described_class.run(['reload'])).to eq(1) }
+      .to output(/pid file not found/).to_stderr
+  end
+
+  it 'returns 1 when the pid is not running' do
+    File.write(pid_path, "9999999\n")
+    allow(Process).to receive(:kill).with(0, 9_999_999).and_raise(Errno::ESRCH)
+    expect { expect(described_class.run(['reload'])).to eq(1) }
+      .to output(/stale pid file/).to_stderr
+  end
+
+  it 'returns 2 when miners.yml is malformed (dry-run parse catches it)' do
+    File.write(miners_path, 'not: [valid')
+    File.write(pid_path, "#{Process.pid}\n")
+    expect { expect(described_class.run(['reload'])).to eq(2) }
+      .to output(/config error/).to_stderr
+  end
+
+  it 'returns 2 when CGMINER_MANAGER_PID_FILE is unset' do
+    stub_const('ENV', ENV.to_h.merge('CGMINER_MANAGER_PID_FILE' => ''))
+    expect { expect(described_class.run(['reload'])).to eq(2) }
+      .to output(/CGMINER_MANAGER_PID_FILE not set/).to_stderr
+  end
+end

--- a/spec/cgminer_manager/cli_reload_spec.rb
+++ b/spec/cgminer_manager/cli_reload_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe CgminerManager::CLI, 'reload' do # rubocop:disable RSpec/Describe
       .to output(/pid file is not an integer/).to_stderr
   end
 
+  it 'returns 1 with a clear message when the pid belongs to another user (EPERM)' do
+    File.write(pid_path, "#{Process.pid}\n")
+    allow(Process).to receive(:kill).with(0, Process.pid).and_raise(Errno::EPERM)
+    expect { expect(described_class.run(['reload'])).to eq(1) }
+      .to output(/pid .* not owned|stale pid file|permission/i).to_stderr
+  end
+
   it 'returns 2 with a miners-file-specific message when miners.yml is missing' do
     File.unlink(miners_path)
     File.write(pid_path, "#{Process.pid}\n")

--- a/spec/cgminer_manager/cli_reload_spec.rb
+++ b/spec/cgminer_manager/cli_reload_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe CgminerManager::CLI, 'reload' do # rubocop:disable RSpec/Describe
     expect { expect(described_class.run(['reload'])).to eq(1) }
       .to output(/pid file is not an integer/).to_stderr
   end
+
+  it 'returns 2 with a miners-file-specific message when miners.yml is missing' do
+    File.unlink(miners_path)
+    File.write(pid_path, "#{Process.pid}\n")
+    # Regression: a previously-ambiguous Errno::ENOENT rescue printed
+    # "pid file not found" whenever the miners file was missing too.
+    expect { expect(described_class.run(['reload'])).to eq(2) }
+      .to output(/miners_file not found/).to_stderr
+  end
 end

--- a/spec/cgminer_manager/cli_spec.rb
+++ b/spec/cgminer_manager/cli_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CgminerManager::CLI do
         code, _stdout, stderr = capture_run(['banana'])
         expect(code).to eq(64)
         expect(stderr).to include('unknown verb: "banana"')
-        expect(stderr).to include('usage: cgminer_manager {run|doctor|version}')
+        expect(stderr).to include('usage: cgminer_manager {run|doctor|reload|version}')
       end
     end
 

--- a/spec/cgminer_manager/cli_spec.rb
+++ b/spec/cgminer_manager/cli_spec.rb
@@ -220,6 +220,64 @@ RSpec.describe CgminerManager::CLI do
           expect(stderr).to include('FAIL: miner 127.0.0.1:4028 in miners.yml but not in monitor')
         end
       end
+
+      context 'when reporting pid-file posture' do
+        around do |example|
+          saved = ENV.to_h.slice('CGMINER_MANAGER_PID_FILE')
+          example.run
+        ensure
+          if saved.key?('CGMINER_MANAGER_PID_FILE')
+            ENV['CGMINER_MANAGER_PID_FILE'] =
+              saved['CGMINER_MANAGER_PID_FILE']
+          else
+            ENV.delete('CGMINER_MANAGER_PID_FILE')
+          end
+        end
+
+        before do
+          allow(client).to receive(:miners).and_return(miners: [{ id: '127.0.0.1:4028' }])
+          allow(miner).to receive(:available?).and_return(true)
+        end
+
+        it 'reports "not configured" when CGMINER_MANAGER_PID_FILE is unset' do
+          ENV.delete('CGMINER_MANAGER_PID_FILE')
+          code, stdout, _stderr = capture_run(['doctor'])
+          expect(code).to eq(0)
+          expect(stdout).to include('pid file: not configured')
+        end
+
+        it 'reports OK when the pid file exists and the pid is alive' do
+          Dir.mktmpdir do |dir|
+            pid_path = File.join(dir, 'cm.pid')
+            File.write(pid_path, "#{Process.pid}\n")
+            ENV['CGMINER_MANAGER_PID_FILE'] = pid_path
+
+            code, stdout, _stderr = capture_run(['doctor'])
+            expect(code).to eq(0)
+            expect(stdout).to include("pid file: OK (pid #{Process.pid})")
+          end
+        end
+
+        it 'reports STALE when the pid is not running' do
+          Dir.mktmpdir do |dir|
+            pid_path = File.join(dir, 'cm.pid')
+            File.write(pid_path, "9999999\n")
+            ENV['CGMINER_MANAGER_PID_FILE'] = pid_path
+            allow(Process).to receive(:kill).with(0, 9_999_999).and_raise(Errno::ESRCH)
+
+            code, _stdout, stderr = capture_run(['doctor'])
+            expect(code).to eq(1)
+            expect(stderr).to include('pid file: STALE')
+          end
+        end
+
+        it 'reports missing when configured but absent' do
+          ENV['CGMINER_MANAGER_PID_FILE'] = '/tmp/cgminer-manager-nope.pid'
+          code, _stdout, stderr = capture_run(['doctor'])
+          expect(code).to eq(1)
+          expect(stderr).to include('pid file configured but missing')
+        end
+      end
     end
   end
 end

--- a/spec/cgminer_manager/config_spec.rb
+++ b/spec/cgminer_manager/config_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe CgminerManager::Config do
       expect { described_class.from_env(env_base.merge('PORT' => 'abc')) }
         .to raise_error(CgminerManager::ConfigError, /PORT/)
     end
+
+    it 'reads CGMINER_MANAGER_PID_FILE when set' do
+      config = described_class.from_env(env_base.merge('CGMINER_MANAGER_PID_FILE' => '/tmp/cm.pid'))
+      expect(config.pid_file).to eq('/tmp/cm.pid')
+    end
+
+    it 'leaves pid_file nil when CGMINER_MANAGER_PID_FILE unset' do
+      config = described_class.from_env(env_base)
+      expect(config.pid_file).to be_nil
+    end
   end
 
   describe '.from_env boot-time admin-auth enforcement' do

--- a/spec/cgminer_manager/http_app_reload_spec.rb
+++ b/spec/cgminer_manager/http_app_reload_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe CgminerManager::HttpApp, '.reload_miners!' do # rubocop:disable RSpec/SpecFilePathFormat
+  let(:dir)  { Dir.mktmpdir }
+  let(:path) { File.join(dir, 'miners.yml') }
+
+  before do
+    File.write(path, "- host: 10.0.0.1\n  port: 4028\n")
+    described_class.configure_for_test!(
+      monitor_url: 'http://example',
+      miners_file: path
+    )
+  end
+
+  after { FileUtils.rm_rf(dir) }
+
+  it 'swaps configured_miners with the freshly parsed file' do
+    File.write(path, "- host: 10.0.0.2\n  port: 4028\n  label: swap\n")
+    count = described_class.reload_miners!
+    expect(count).to eq(1)
+    expect(described_class.settings.configured_miners)
+      .to eq([['10.0.0.2', 4028, 'swap'].freeze].freeze)
+  end
+
+  it 'keeps old miners and returns nil when YAML is malformed' do
+    old = described_class.settings.configured_miners
+    File.write(path, 'not: [valid')
+    expect(described_class.reload_miners!).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+
+  it 'keeps old miners when file goes missing' do
+    old = described_class.settings.configured_miners
+    File.unlink(path)
+    expect(described_class.reload_miners!).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+
+  it 'keeps old miners when validation fails (wrong shape)' do
+    old = described_class.settings.configured_miners
+    File.write(path, "just-a-string\n")
+    expect(described_class.reload_miners!).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+end

--- a/spec/cgminer_manager/server_signal_spec.rb
+++ b/spec/cgminer_manager/server_signal_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe CgminerManager::Server do
+  describe '#install_signal_handlers' do
+    it 'traps INT and TERM as :stop and HUP as :reload into @signals' do
+      server = described_class.allocate
+      server.instance_variable_set(:@config, instance_double(CgminerManager::Config))
+      server.instance_variable_set(:@signals, Queue.new)
+
+      trapped = {}
+      allow(Signal).to receive(:trap) do |sig, &blk|
+        trapped[sig] = blk
+      end
+
+      server.send(:install_signal_handlers)
+
+      %w[INT TERM HUP].each { |s| expect(trapped).to have_key(s) }
+
+      trapped['INT'].call
+      trapped['TERM'].call
+      trapped['HUP'].call
+
+      signals = server.instance_variable_get(:@signals)
+      drained = [signals.pop, signals.pop, signals.pop]
+      expect(drained).to contain_exactly(:stop, :stop, :reload)
+    end
+  end
+
+  describe '#perform_reload' do
+    it 'calls HttpApp.reload_miners! and logs reload.ok on success' do
+      server = described_class.allocate
+      server.instance_variable_set(:@config, instance_double(CgminerManager::Config))
+
+      allow(CgminerManager::HttpApp).to receive(:reload_miners!).and_return(3)
+      allow(CgminerManager::Logger).to receive(:info)
+
+      server.send(:perform_reload)
+
+      expect(CgminerManager::Logger).to have_received(:info)
+        .with(event: 'reload.signal_received')
+      expect(CgminerManager::Logger).to have_received(:info)
+        .with(event: 'reload.ok', miners: 3)
+    end
+
+    it 'does not log reload.ok when HttpApp.reload_miners! returns nil' do
+      server = described_class.allocate
+      server.instance_variable_set(:@config, instance_double(CgminerManager::Config))
+
+      allow(CgminerManager::HttpApp).to receive(:reload_miners!).and_return(nil)
+      allow(CgminerManager::Logger).to receive(:info)
+
+      server.send(:perform_reload)
+
+      expect(CgminerManager::Logger).to have_received(:info)
+        .with(event: 'reload.signal_received')
+      expect(CgminerManager::Logger).not_to have_received(:info)
+        .with(hash_including(event: 'reload.ok'))
+    end
+  end
+
+  describe '#write_pid_file / #unlink_pid_file' do
+    let(:pid_path) { File.join(Dir.mktmpdir, 'test.pid') }
+    let(:config)   { instance_double(CgminerManager::Config, pid_file: pid_path) }
+    let(:server) do
+      s = described_class.allocate
+      s.instance_variable_set(:@config, config)
+      s
+    end
+
+    after { FileUtils.rm_f(pid_path) }
+
+    it 'writes the current pid to the configured path' do
+      allow(CgminerManager::Logger).to receive(:info)
+      server.send(:write_pid_file)
+      expect(File.read(pid_path).strip).to eq(Process.pid.to_s)
+    end
+
+    it 'unlinks the pid file' do
+      File.write(pid_path, "#{Process.pid}\n")
+      server.send(:unlink_pid_file)
+      expect(File.exist?(pid_path)).to be(false)
+    end
+
+    it 'tolerates an already-deleted pid file on unlink' do
+      expect { server.send(:unlink_pid_file) }.not_to raise_error
+    end
+
+    it 'is a no-op when pid_file is nil' do
+      allow(config).to receive(:pid_file).and_return(nil)
+      expect { server.send(:write_pid_file) }.not_to raise_error
+      expect { server.send(:unlink_pid_file) }.not_to raise_error
+    end
+  end
+end

--- a/spec/integration/full_boot_spec.rb
+++ b/spec/integration/full_boot_spec.rb
@@ -54,4 +54,71 @@ RSpec.describe 'full boot', type: :integration do
     _, status = Process.wait2(pid)
     expect(status.exitstatus).to eq(0)
   end
+
+  # SIGHUP path: rewrite miners.yml, send SIGHUP to the spawned process,
+  # and observe (1) the new miner visible via /api/v1/ping.json's
+  # unavailable_miners count (both 127.0.0.1:* probes ECONNREFUSED
+  # instantly) and (2) the expected reload.* events in captured stderr.
+  # The stderr assertion is the regression guard against a future change
+  # that silently swallows SIGHUP — e.g., Puma reinstalling its own HUP
+  # trap between our install and the process boundary.
+  it 'reloads miners on SIGHUP' do # rubocop:disable RSpec/ExampleLength
+    dir         = Dir.mktmpdir
+    miners_path = File.join(dir, 'miners.yml')
+    pid_path    = File.join(dir, 'cm.pid')
+    File.write(miners_path, "- host: 127.0.0.1\n  port: 4028\n")
+
+    env = {
+      'CGMINER_MONITOR_URL' => 'http://127.0.0.1:65501',
+      'MINERS_FILE' => miners_path,
+      'SESSION_SECRET' => 'x' * 64,
+      'PORT' => '6124',
+      'BIND' => '127.0.0.1',
+      'SHUTDOWN_TIMEOUT' => '3',
+      'CGMINER_MANAGER_PID_FILE' => pid_path,
+      'CGMINER_MANAGER_ADMIN_AUTH' => 'off',
+      'LOG_FORMAT' => 'json'
+    }
+
+    log_r, log_w = IO.pipe
+    pid = spawn(env, 'bundle', 'exec', 'bin/cgminer_manager', 'run',
+                chdir: File.expand_path('../..', __dir__),
+                out: log_w, err: log_w)
+    log_w.close
+
+    begin
+      wait_for_bind!('127.0.0.1', 6124)
+
+      deadline = Time.now + 5
+      sleep 0.05 until File.exist?(pid_path) || Time.now > deadline
+      expect(File.read(pid_path).strip).to eq(pid.to_s)
+
+      initial = JSON.parse(Net::HTTP.get(URI('http://127.0.0.1:6124/api/v1/ping.json')))
+      expect(initial['available_miners'].to_i + initial['unavailable_miners'].to_i).to eq(1)
+
+      File.write(miners_path,
+                 "- host: 127.0.0.1\n  port: 4028\n" \
+                 "- host: 127.0.0.1\n  port: 4029\n")
+      Process.kill('HUP', pid)
+
+      deadline = Time.now + 5
+      total = 0
+      until Time.now > deadline
+        ping = JSON.parse(Net::HTTP.get(URI('http://127.0.0.1:6124/api/v1/ping.json')))
+        total = ping['available_miners'].to_i + ping['unavailable_miners'].to_i
+        break if total == 2
+
+        sleep 0.1
+      end
+      expect(total).to eq(2)
+    ensure
+      Process.kill('TERM', pid) rescue nil # rubocop:disable Style/RescueModifier
+      Process.wait(pid)
+      logged = log_r.read
+      log_r.close
+      expect(logged).to match(/reload\.signal_received/)
+      expect(logged).to match(/reload\.ok/)
+      FileUtils.rm_rf(dir)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Operators can add, remove, or re-label a miner in `config/miners.yml` and have it picked up without restarting the server.

- **SIGHUP handler** (`lib/cgminer_manager/server.rb`) — `@stop` queue renamed to `@signals` carrying symbolic messages; `:stop` (INT/TERM) drops through the existing shutdown path, `:reload` triggers `HttpApp.reload_miners!`. Signal handler only pushes the symbol; the main thread does the work so Ruby's signal-safe subset doesn't apply.
- **Atomic swap** (`lib/cgminer_manager/http_app.rb`) — `self.reload_miners!` re-parses `settings.miners_file` and replaces `settings.configured_miners` via `Sinatra::Base.set`. Frozen tuple Array + MRI GVL → no torn reads for in-flight route handlers. Parse/validation failure logs `event=reload.failed` and keeps the old list.
- **PID file lifecycle** — `CGMINER_MANAGER_PID_FILE` (optional) written after Puma's `on_booted`, unlinked in `run`'s `ensure`.
- **`reload` CLI verb** (`lib/cgminer_manager/cli.rb`) — dry-run-parses miners.yml locally so typos exit 2 at the operator's terminal *before* sending SIGHUP; reads the PID file, probes with `kill(0)`, sends SIGHUP.
- **`doctor` PID-file posture** — audit-honest report: `not configured` / `OK (pid N)` / `STALE` / `missing`.
- **Integration test** — spawns real `bin/cgminer_manager run`, rewrites miners.yml, sends SIGHUP, asserts (a) `/api/v1/ping.json` shows the new miner count and (b) `reload.signal_received` + `reload.ok` appear in captured stdout. The log-match is the regression guard against a future change silently swallowing SIGHUP (e.g., Puma reinstalling its own HUP trap between our install and the process boundary).

## Test plan

- [x] `bundle exec rake` passes (240 examples, 0 failures, rubocop clean)
- [x] Integration test sends real SIGHUP to a spawned server and observes reload
- [x] Manual smoke: `reload` verb exits 2 on malformed miners.yml *before* signaling; SIGHUP with malformed YAML logs `reload.failed` and keeps the old list
- [ ] After merge: bump to v1.4.0, update CHANGELOG release date on master, tag + push — multi-arch container image publishes automatically

## Risks

- Correctness argument rests on MRI GVL. No TruffleRuby/JRuby target today (`.ruby-version` pins MRI 4.0.2), but worth re-examining if that ever changes.
- `@stop` → `@signals` rename is contained to `Server` private state; no external callers.