### PR TITLE
Add bundle-audit and brakeman to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
       - run: bundle install --jobs 1
       - run: bundle exec rubocop
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - run: bundle install --jobs 1
+      - run: bundle exec bundle-audit check --update
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
       - run: bundle install --jobs 1
       - run: bundle exec bundle-audit check --update
 
+  brakeman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - run: bundle install --jobs 1
+      - run: bundle exec brakeman --force --no-summary --quiet --exit-on-warn
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Added
+- **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
+  job runs `bundle exec bundle-audit check --update` on every push
+  and PR, gating merges on known CVEs in `Gemfile.lock`. Also
+  available locally as `bundle exec rake audit`.
 - **Dependabot config** (`.github/dependabot.yml`). Weekly bump PRs
   for Bundler, GitHub Actions, and Docker `FROM` base images, with
   `open-pull-requests-limit: 3` per ecosystem. `versioning-strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [Unreleased]
 
 ### Added
+- **`brakeman` in CI** (`.github/workflows/ci.yml`,
+  `config/brakeman.yml`). New `brakeman` job runs
+  `bundle exec brakeman --force --no-summary --quiet --exit-on-warn`
+  on every push and PR, failing CI on any static security warning.
+  Brakeman 8.x is Rails-focused; `force_scan: true` in
+  `config/brakeman.yml` makes it scan this Sinatra app anyway. The
+  Rails-specific checks (Controllers / Models) report zero by design,
+  but the ~79 generic-Ruby checks (Execute, Evaluation, Send,
+  Deserialize, JSONParsing, TemplateInjection, XSS, etc.) still run
+  against `lib/` and the Haml views, covering the admin dashboard
+  surface. Also available locally as `bundle exec rake brakeman`.
+  First-run result: zero warnings; `config/brakeman.ignore` not
+  created.
 - **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
   job runs `bundle exec bundle-audit check --update` on every push
   and PR, gating merges on known CVEs in `Gemfile.lock`. Also

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'brakeman', '>= 7.0'
   gem 'bundler-audit', '>= 0.9'
   # parallel 2.x requires Ruby >= 3.3; pin to 1.x so our Ruby 3.2 matrix entry
   # can still bundle. Transitive dep of rubocop / rubocop-ast.

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'bundler-audit', '>= 0.9'
   # parallel 2.x requires Ruby >= 3.3; pin to 1.x so our Ruby 3.2 matrix entry
   # can still bundle. Transitive dep of rubocop / rubocop-ast.
   gem 'parallel', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,9 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.1)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     cgminer_api_client (0.3.0)
     crack (1.0.1)
       bigdecimal
@@ -163,6 +166,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bundler-audit (>= 0.9)
   cgminer_manager!
   parallel (< 2.0)
   rack-test (>= 2.1)
@@ -179,6 +183,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.3.0) sha256=89a7cbec7b66338a3b21d71967b4e42b3f9f1fafacc2ded58263a8127d98876e
   cgminer_manager (1.4.0)
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.1)
+    brakeman (8.0.4)
+      racc
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
@@ -166,6 +168,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  brakeman (>= 7.0)
   bundler-audit (>= 0.9)
   cgminer_manager!
   parallel (< 2.0)
@@ -183,6 +186,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.3.0) sha256=89a7cbec7b66338a3b21d71967b4e42b3f9f1fafacc2ded58263a8127d98876e
   cgminer_manager (1.4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,11 @@ RuboCop::RakeTask.new
 
 task default: %i[rubocop spec]
 
+desc 'Check Gemfile.lock against the ruby-advisory-db for known CVEs'
+task :audit do
+  sh 'bundle exec bundle-audit check --update'
+end
+
 namespace :spec do
   desc 'Capture /v2/* responses from $CGMINER_MONITOR_URL into spec/fixtures/monitor/'
   task :refresh_monitor_fixtures do

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,11 @@ task :audit do
   sh 'bundle exec bundle-audit check --update'
 end
 
+desc 'Static security analysis via brakeman'
+task :brakeman do
+  sh 'bundle exec brakeman --force --no-summary --quiet --exit-on-warn'
+end
+
 namespace :spec do
   desc 'Capture /v2/* responses from $CGMINER_MONITOR_URL into spec/fixtures/monitor/'
   task :refresh_monitor_fixtures do

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,16 @@
+---
+# cgminer_manager is a Sinatra app, not Rails. brakeman's Rails-focused
+# controller/model detection reports "Controllers: 0, Models: 0" here —
+# expected. The generic Ruby checks (Execute, Evaluation, Send,
+# Deserialize, JSONParsing, TemplateInjection, XSS, etc.) still run
+# against lib/ and the Haml views under views/, which covers the admin
+# dashboard surface. `force_scan: true` makes brakeman scan anyway
+# instead of exiting 0 with "Please supply the path to a Rails
+# application." `exit_on_warn: true` flips exit code on warnings so
+# CI fails loudly. CLI invocations in ci.yml and Rakefile pass these
+# flags explicitly as well, so an accidental delete of this file
+# doesn't silently turn the CI check into a no-op.
+
+:app_path: "."
+:force_scan: true
+:exit_on_warn: true


### PR DESCRIPTION
## Summary
Two commits:

1. **`bundle-audit`** — new `audit` job in `ci.yml` gates merges on known CVEs in `Gemfile.lock`. Matches the rollout in api_client (PR #5) and monitor (PR #7).
2. **`brakeman`** — new `brakeman` job in `ci.yml` runs static security analysis. `--force` is required because brakeman 8.x is Rails-focused and refuses to scan Sinatra apps by default; without it, the CI check would silently exit 0 without scanning anything. `config/brakeman.yml` sets `force_scan` / `exit_on_warn` / `app_path` so local `bundle exec brakeman` does the right thing too. Rails-specific checks report zero by design (Sinatra has no controllers/models in brakeman's sense), but the ~79 generic-Ruby checks still run against `lib/` and the Haml views — meaningful coverage of the admin dashboard surface. First-run: zero warnings; `config/brakeman.ignore` not created.

`rake audit` and `rake brakeman` tasks available locally; not in `rake default`.

## Test plan
- [x] `bundle exec rake audit` passes locally (1078 advisories; no vulnerabilities found).
- [x] `bundle exec rake brakeman` passes locally (exit 0, "No warnings found").
- [x] Non-integration rspec + rubocop still green (195 examples, 0 failures; 61 files, no offenses).
- [x] CI `audit` job turns green on the PR.
- [x] CI `brakeman` job turns green on the PR.
- [x] `lint`, `test`, `integration` jobs unaffected.