### PR TITLE
chore: standardize duration_ms across log sites; add logging stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Changed
+- **Log-key consistency — `duration_ms` everywhere.** The
+  `admin.result` and `http.request` log events previously emitted
+  their timing under `elapsed_ms` and `render_ms` respectively;
+  both now emit `duration_ms` to match `monitor.call` and the
+  house-wide standard. No Ruby API change — `AdminLogging.result_log_entry`
+  and the `http.request` after-filter still accept the same inputs.
+  **Log consumers that keyed off `elapsed_ms` or `render_ms` must
+  update their queries to `duration_ms`.** The `cgminer_monitor`
+  canonical log-schema doc (`cgminer_monitor/docs/log_schema.md`)
+  pins `duration_ms` as the standardized reserved key.
+- `docs/interfaces.md`, `docs/workflows.md`, and `docs/architecture.md`
+  updated to name `duration_ms` in their event tables and Mermaid
+  sequence diagrams.
+
 ## [1.5.0] — 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+- **`docs/logging.md`** — short stub naming the manager-owned log
+  event namespaces (`admin.*`, `rate_limit.*`, `monitor.*`, `http.*`),
+  the shared namespaces (`server.*`, `reload.*`, `puma.*`), and the
+  house conventions. Links to `cgminer_monitor/docs/log_schema.md`
+  as the cross-repo source of truth for reserved keys, the full
+  event catalog, and evolution rules.
+
 ### Changed
 - **Log-key consistency — `duration_ms` everywhere.** The
   `admin.result` and `http.request` log events previously emitted

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ All admin POSTs emit (at minimum) one entry event and one exit event, threaded b
 |---|---|---|
 | `admin.command` | on typed-allowlist POST | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope` |
 | `admin.raw_command` | on `/admin/run` POST | same as above + `args` |
-| `admin.result` | after the commander returns | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `elapsed_ms` |
+| `admin.result` | after the commander returns | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `duration_ms` |
 | `admin.scope_rejected` | 422 from scope check | `request_id`, `command`, `scope` |
 | `admin.auth_failed` | 401 from `AdminAuth` | `reason` (`missing_creds`/`bad_creds`/`user_mismatch`), `path`, `remote_ip`, `user_agent` |
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -173,7 +173,7 @@ If monitor's response is missing a column (e.g., per-miner availability), the pr
 
 ### Request logging
 
-Every HTTP request emits an `http.request` log line in the `after` filter with `path`, `method`, `status`, `render_ms`. For admin routes the `before` filter generates a `request_id = SecureRandom.uuid` which threads through the admin audit events (see `architecture.md` → admin audit log schema).
+Every HTTP request emits an `http.request` log line in the `after` filter with `path`, `method`, `status`, `duration_ms`. For admin routes the `before` filter generates a `request_id = SecureRandom.uuid` which threads through the admin audit events (see `architecture.md` → admin audit log schema).
 
 ## 5. Upstream: `cgminer_monitor` `/v2/*`
 
@@ -216,12 +216,12 @@ Notable events (non-exhaustive):
 |---|---|---|
 | `server.start`, `server.stopping`, `server.stopped` | Server | standard |
 | `puma.crash` | Server | `error`, `message` |
-| `http.request` | HttpApp (after filter) | `path`, `method`, `status`, `render_ms` |
+| `http.request` | HttpApp (after filter) | `path`, `method`, `status`, `duration_ms` |
 | `http.500` | HttpApp error handler | `error`, `message`, `backtrace` (first 10) |
 | `monitor.call` | MonitorClient | `url`, `status`, `duration_ms` |
 | `monitor.call.failed` | MonitorClient | `url`, `error`, `message` |
 | `admin.command`, `admin.raw_command` | HttpApp admin routes | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope`, `args` |
-| `admin.result` | HttpApp admin routes | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `elapsed_ms` |
+| `admin.result` | HttpApp admin routes | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `duration_ms` |
 | `admin.scope_rejected` | HttpApp `/admin/run` | `request_id`, `command`, `scope` |
 | `admin.auth_failed` | AdminAuth | `reason`, `path`, `remote_ip`, `user_agent` |
 | `admin.auth_misconfigured` | AdminAuth | `path`, `remote_ip`, `user_agent` — admin path hit with neither creds nor `=off` (defense-in-depth for post-boot env tampering; boot-time `Config.from_env` should have caught it first). Emits a `503` response. |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,39 @@
+# Logging
+
+`cgminer_manager` emits structured logs via `CgminerManager::Logger.{info,warn,error}(event: '...', ...)`. Every entry is a single-line JSON object on stdout (text mode available for local debugging via `CGMINER_MANAGER_LOG_FORMAT=text`).
+
+The full cross-repo contract — reserved keys, standard key types, complete event catalog, evolution rules, and grep recipes — lives in `cgminer_monitor`:
+
+→ **[cgminer_monitor/docs/log_schema.md](https://github.com/jramos/cgminer_monitor/blob/develop/docs/log_schema.md)**
+
+Consumers and contributors should treat that document as the source of truth.
+
+## Namespaces owned by cgminer_manager
+
+- `admin.*` — admin surface (`admin.command`, `admin.result`, `admin.auth_failed`, `admin.auth_misconfigured`). Construction helpers live in `lib/cgminer_manager/admin_logging.rb`.
+- `rate_limit.*` — the per-IP rate limiter (`rate_limit.exceeded`).
+- `monitor.*` — manager's HTTP client calls to `cgminer_monitor` (`monitor.call`, `monitor.call.failed`). The prefix names the *dependency*, not the emitter.
+- `http.request`, `http.500` — the Rack-level after-filter and the `error Exception` handler in `HttpApp`.
+
+## Namespaces shared with cgminer_monitor
+
+- `server.*` — process lifecycle (`server.start`, `server.stopping`, `server.stopped`, `server.pid_file_written`).
+- `reload.*` — SIGHUP hot-reload (`reload.signal_received`, `reload.ok`, `reload.failed`). `reload.partial` is monitor-only within this namespace.
+- `puma.*` — Puma thread crashes (`puma.crash`).
+- `http.unhandled_error` — uncaught exceptions below the Sinatra error handler (both repos emit).
+
+## House conventions
+
+- **Bare `Logger.warn(...)`** inside `module CgminerManager`. Don't fully-qualify as `CgminerManager::Logger.warn(...)` — module lookup finds the sibling.
+- **Scalar `miner:` for a rig id** (`"host:port"`); plural `miners:` for a count. Don't reintroduce `miner_id:`.
+- **Timing is `duration_ms` everywhere.** `admin.result` and `http.request` previously used `elapsed_ms` / `render_ms`; that was renamed to match the schema contract. New events should use `duration_ms`.
+- **Exceptions serialize as strings.** `error: e.class.to_s`, `message: e.message`, `backtrace: e.backtrace&.first(10)`. Never log an exception object directly.
+- **Admin events never log raw credentials.** `admin.command` carries `session_id_hash` (SHA256-hex prefix) and `user` (username), never the raw session id or password.
+
+## Adding a new event
+
+1. Decide the namespace. If it fits under an existing `cgminer_manager`-owned prefix, use that. If not, reserve a new prefix in `cgminer_monitor/docs/log_schema.md` first.
+2. Name the event `<namespace>.<action>` (lowercase, dotted, one dot).
+3. Reuse standard keys where possible (see schema doc's "Standard keys" table). Minting a new key requires adding a row to that table.
+4. Add an entry to the schema doc's event catalog with the required + optional keys.
+5. Ship a CHANGELOG `### Changed` entry if the event is new on an existing namespace, or `### Added` if the namespace itself is new.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -95,7 +95,7 @@ sequenceDiagram
     HttpApp->>HAML: haml :'manager/index' with @miner_pool, @miner_data, @bad_chain_elements, @view
     HAML->>HAML: render layout, _header, manager/index (Summary/Miner Pool/Admin tabs),
     HAML-->>HttpApp: HTML
-    HttpApp->>Logger: after-filter: 'http.request' path=/ status=200 render_ms=...
+    HttpApp->>Logger: after-filter: 'http.request' path=/ status=200 duration_ms=...
     HttpApp-->>Puma: 200 HTML
     Puma-->>Browser: response
 ```
@@ -216,7 +216,7 @@ sequenceDiagram
     end
     Cmdr-->>HttpApp: FleetWriteResult
 
-    HttpApp->>Logger: 'admin.result' request_id=... ok_count=N failed_count=M elapsed_ms=...
+    HttpApp->>Logger: 'admin.result' request_id=... ok_count=N failed_count=M duration_ms=...
     HttpApp->>HAML: render_admin_result(result)
     HAML-->>HttpApp: HTML fragment (shared/_fleet_write)
     HttpApp-->>Puma: 200 HTML

--- a/lib/cgminer_manager/admin_logging.rb
+++ b/lib/cgminer_manager/admin_logging.rb
@@ -42,7 +42,7 @@ module CgminerManager
         scope: scope,
         ok_count: result.ok_count,
         failed_count: result.failed_count,
-        elapsed_ms: ((Time.now - started_at) * 1000).round
+        duration_ms: ((Time.now - started_at) * 1000).round
       }
     end
   end

--- a/lib/cgminer_manager/http_app.rb
+++ b/lib/cgminer_manager/http_app.rb
@@ -152,7 +152,7 @@ module CgminerManager
                   path: request.path,
                   method: request.request_method,
                   status: response.status,
-                  render_ms: ((Time.now - @request_started_at) * 1000).round)
+                  duration_ms: ((Time.now - @request_started_at) * 1000).round)
     end
 
     # Wires the session-cookie + admin-auth + CSRF middleware stack.

--- a/spec/cgminer_manager/admin_logging_spec.rb
+++ b/spec/cgminer_manager/admin_logging_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CgminerManager::AdminLogging do
         ok_count: 3,
         failed_count: 1
       )
-      expect(entry[:elapsed_ms]).to be_between(200, 2000)
+      expect(entry[:duration_ms]).to be_between(200, 2000)
     end
   end
 end


### PR DESCRIPTION
## Summary

- **Log-key consistency.** `admin.result` previously emitted `elapsed_ms:` and `http.request` emitted `render_ms:`; both are the same concept as `monitor.call`'s existing `duration_ms:`. Rename both to `duration_ms` so the repo (and the canonical `cgminer_monitor/docs/log_schema.md` contract) uses one name for one concept. No Ruby API change.
- **Docs sync.** `docs/interfaces.md`, `docs/workflows.md`, and `docs/architecture.md` previously named `render_ms` / `elapsed_ms` in event tables and Mermaid sequence diagrams; all updated to `duration_ms` so the repo doesn't self-contradict on merge day.
- **New `docs/logging.md` stub.** Short file naming the manager-owned and shared log namespaces, house conventions, and a link to `cgminer_monitor/docs/log_schema.md` as the cross-repo source of truth.

## Log-consumer impact

Anyone querying on `elapsed_ms` or `render_ms` must update to `duration_ms`. No Ruby-level breaking changes; the log-key rename only affects downstream aggregators (Loki/Datadog/Vector/grep).

## Scope

Companion PR to `cgminer_monitor` PR #9 which lands the canonical `docs/log_schema.md` that this stub links to. Land `cgminer_monitor` first so the cross-repo link resolves immediately.

Two commits:
1. `refactor(logging): standardize timing key on duration_ms`
2. `docs: add logging.md stub linking to canonical schema`

## Test plan

- [x] `bundle exec rake` — 280 examples, 0 failures; rubocop clean
- [x] `grep -rn 'elapsed_ms\\|render_ms' lib/ spec/ docs/` — zero hits
- [ ] Eyeball `docs/logging.md` on the GitHub PR diff view — cross-repo link resolves after cgminer_monitor PR #9 merges