### PR TITLE
test: contract-test MonitorClient reads against monitor OpenAPI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,8 @@ RSpec/DescribeClass:
   Exclude:
     # Integration specs describe HTTP routes/behaviors, not Ruby classes.
     - 'spec/integration/**/*_spec.rb'
+    # Contract specs describe cross-repo shape contracts, not classes.
+    - 'spec/contract/**/*_spec.rb'
 
 RSpec/MultipleDescribes:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [Unreleased]
 
 ### Added
+- **Contract test against monitor's OpenAPI spec**
+  (`spec/contract/monitor_openapi_contract_spec.rb`). Asserts that
+  every envelope key `MonitorClient` + view-models read from
+  cgminer_monitor's `/v2/*` responses is declared in the monitor-
+  shipped OpenAPI (`lib/cgminer_monitor/openapi.yml`). Catches
+  field-rename or envelope-reshape drift at CI time instead of at
+  page-load. Scope is envelope-only (`miners`, `host`, `port`,
+  `available`, `id`, `ok`, `response`, `error`, `fields`, `data`,
+  `status`); cgminer-payload drift stays in api_client territory.
+  Monitor is added as a CI-only dev dep in `Gemfile` pinned to
+  `tag: 'v1.2.0'` under a `GIT` source — bumping the tag is a
+  deliberate reviewable event that surfaces OpenAPI revisions in
+  manager's PR history.
 - **`docs/logging.md`** — short stub naming the manager-owned log
   event namespaces (`admin.*`, `rate_limit.*`, `monitor.*`, `http.*`),
   the shared namespaces (`server.*`, `reload.*`, `puma.*`), and the

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,14 @@ gemspec
 group :development, :test do
   gem 'brakeman', '>= 7.0'
   gem 'bundler-audit', '>= 0.9'
+  # CI-only: pins the monitor release whose OpenAPI spec we contract-test
+  # against (spec/contract/monitor_openapi_contract_spec.rb). Bumping the
+  # tag is a deliberate reviewable event — if monitor bumps its OpenAPI
+  # and our contract assumptions drift, the pin bump surfaces it.
+  gem 'cgminer_monitor',
+      git: 'https://github.com/jramos/cgminer_monitor.git',
+      tag: 'v1.2.0',
+      require: false
   # parallel 2.x requires Ruby >= 3.3; pin to 1.x so our Ruby 3.2 matrix entry
   # can still bundle. Transitive dep of rubocop / rubocop-ast.
   gem 'parallel', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/jramos/cgminer_monitor.git
+  revision: 4c291b66f1196b3d4f181033081147168b8cfe2c
+  tag: v1.2.0
+  specs:
+    cgminer_monitor (1.2.0)
+      cgminer_api_client (~> 0.3.0)
+      mongoid (~> 9.0)
+      puma (>= 6.0)
+      rack-cors (~> 2.0)
+      sinatra (>= 4.0)
+
 PATH
   remote: .
   specs:
@@ -13,6 +25,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
@@ -20,16 +47,20 @@ GEM
     bigdecimal (4.1.1)
     brakeman (8.0.4)
       racc
+    bson (5.2.0)
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
     cgminer_api_client (0.3.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
     domain_name (0.6.20240107)
+    drb (2.2.3)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -57,6 +88,8 @@ GEM
     http-cookie (1.1.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
     json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -64,6 +97,16 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mongo (2.24.0)
+      base64
+      bson (>= 4.14.1, < 6.0.0)
+    mongoid (9.0.10)
+      activemodel (>= 5.1, < 8.2, != 7.0.0)
+      concurrent-ruby (>= 1.0.5, < 2.0)
+      mongo (>= 2.18.0, < 3.0.0)
     multi_json (1.20.1)
     mustermann (3.1.1)
     nio4r (2.7.5)
@@ -77,6 +120,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -124,6 +169,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -146,9 +192,12 @@ GEM
     temple (0.10.4)
     thor (1.5.0)
     tilt (2.7.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uri (1.1.1)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -171,6 +220,7 @@ DEPENDENCIES
   brakeman (>= 7.0)
   bundler-audit (>= 0.9)
   cgminer_manager!
+  cgminer_monitor!
   parallel (< 2.0)
   rack-test (>= 2.1)
   rake (>= 13.2)
@@ -182,18 +232,25 @@ DEPENDENCIES
   webmock (>= 3.23)
 
 CHECKSUMS
+  activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.3.0) sha256=89a7cbec7b66338a3b21d71967b4e42b3f9f1fafacc2ded58263a8127d98876e
   cgminer_manager (1.5.0)
+  cgminer_monitor (1.2.0)
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
@@ -211,11 +268,15 @@ CHECKSUMS
   http (5.3.1) sha256=c50802d8e9be3926cb84ac3b36d1a31fbbac383bc4cbecdce9053cb604231d7d
   http-cookie (1.1.4) sha256=8dd8011dedcae5f91af2671b7ba878c4a9e89f0f6384790c1f4cdd176f5e3ada
   http-form_data (2.3.0) sha256=cc4eeb1361d9876821e31d7b1cf0b68f1cf874b201d27903480479d86448a5f3
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   llhttp-ffi (0.5.1) sha256=9a25a7fc19311f691a78c9c0ac0fbf4675adbd0cca74310228fdf841018fa7bc
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
+  mongo (2.24.0) sha256=ff23d23157dc4a1f90f162625460d973b7ffa89ee78e6bb45a6003b3f5a67190
+  mongoid (9.0.10) sha256=351192e70027276748f3c946b8926fad9254356e36021dacb5cec08d0740f21d
   multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
   mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
@@ -226,6 +287,7 @@ CHECKSUMS
   puma (6.6.1) sha256=b9b56e4a4ea75d1bfa6d9e1972ee2c9f43d0883f011826d914e8e37b3694ea1e
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-cors (2.0.2) sha256=415d4e1599891760c5dc9ef0349c7fecdf94f7c6a03e75b2e7c2b54b82adda1b
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
@@ -243,6 +305,7 @@ CHECKSUMS
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
@@ -251,8 +314,10 @@ CHECKSUMS
   temple (0.10.4) sha256=b7a1e94b6f09038ab0b6e4fe0126996055da2c38bec53a8a336f075748fff72c
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
 
 BUNDLED WITH

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -35,6 +35,9 @@ group :development, :test do
   gem 'rubocop-rspec', '>= 2.27'
   gem 'simplecov',     '>= 0.22'
   gem 'webmock',       '>= 3.23'
+  gem 'cgminer_monitor',
+      git: 'https://github.com/jramos/cgminer_monitor.git',
+      tag: 'vX.Y.Z', require: false
 end
 ```
 
@@ -47,6 +50,7 @@ end
 | `rubocop`, `rubocop-rake`, `rubocop-rspec` | Linter and plugins. |
 | `simplecov` | Code coverage. Started in `spec_helper.rb` with coverage enforcement gated by `ENFORCE_COVERAGE=1` (set automatically by the rake task, not set when running filtered specs directly). |
 | `webmock` | Stubs outbound HTTP calls to `cgminer_monitor`. See `spec/support/monitor_stubs.rb` for the helper module. |
+| `cgminer_monitor` | CI-only dev dep, pinned by git tag. Ships its OpenAPI spec inside the gem at `lib/cgminer_monitor/openapi.yml`; `spec/contract/monitor_openapi_contract_spec.rb` loads it via `Gem::Specification.find_by_name` and asserts that every `/v2/*` envelope key `MonitorClient` reads is declared. Bumping the tag is a deliberate reviewable event — OpenAPI revisions surface as a pin bump PR. `require: false` keeps monitor out of manager's runtime autoload path; only the spec loader reaches into the gem dir. |
 
 ## Ruby version support
 

--- a/spec/contract/monitor_openapi_contract_spec.rb
+++ b/spec/contract/monitor_openapi_contract_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+# Cross-repo contract test: every envelope field that MonitorClient +
+# view-models read from cgminer_monitor's /v2/* responses must be
+# declared in the monitor-shipped OpenAPI spec. Catches field rename
+# or envelope reshape at CI time instead of at page-load time.
+#
+# The OpenAPI yml ships inside the cgminer_monitor gem at
+# lib/cgminer_monitor/openapi.yml — cgminer_monitor.gemspec includes
+# `lib/**/*.yml` in the files glob, so Gem::Specification.find_by_name
+# resolves a predictable absolute path. Manager pins the monitor gem
+# by tag in the Gemfile :development, :test group; bumping the pin is
+# a deliberate reviewable event that regenerates this contract.
+#
+# Scope is envelope-only: `:miners`, `:host`, `:port`, `:available`,
+# `:id`, `:ok`, `:response`, `:error`, `:fields`, `:data`, `:status`.
+# Cgminer payload drift (`SUMMARY`, `DEVS`, `MHS 5s`, etc.) is a
+# separate concern covered by api_client + FakeCgminer fixtures.
+RSpec.describe 'MonitorClient ↔ monitor OpenAPI contract' do
+  let(:openapi) do
+    spec = Gem::Specification.find_by_name('cgminer_monitor')
+    YAML.load_file(File.join(spec.gem_dir, 'lib/cgminer_monitor/openapi.yml'))
+  end
+
+  # Follows at most one level of $ref against components.schemas to
+  # transparently resolve the SnapshotEnvelope + GraphDataEnvelope
+  # factoring. Inline schemas (/v2/miners, /v2/healthz) pass through.
+  def response_schema(openapi, path, method: 'get', status: '200')
+    op = openapi.dig('paths', path, method)
+    raise "path #{method.upcase} #{path} not in OpenAPI" if op.nil?
+
+    schema = op.dig('responses', status, 'content', 'application/json', 'schema')
+    if schema.is_a?(Hash) && schema['$ref']
+      ref = schema['$ref'].sub(%r{^#/components/schemas/}, '')
+      schema = openapi.dig('components', 'schemas', ref)
+    end
+    schema
+  end
+
+  def declared_properties(schema)
+    (schema['properties'] || {}).keys
+  end
+
+  describe 'GET /v2/miners' do
+    it 'declares the keys MonitorClient#miners reads' do
+      schema = response_schema(openapi, '/v2/miners')
+      expect(declared_properties(schema)).to include('miners')
+
+      miner_items = schema.dig('properties', 'miners', 'items')
+      %w[id host port available].each do |k|
+        expect(declared_properties(miner_items)).to include(k)
+      end
+    end
+  end
+
+  describe 'GET /v2/miners/{miner}/{summary,stats,devices,pools}' do
+    %w[summary stats devices pools].each do |verb|
+      it "#{verb} envelope declares ok, response, error" do
+        schema = response_schema(openapi, "/v2/miners/{miner}/#{verb}")
+        %w[ok response error].each do |k|
+          expect(declared_properties(schema)).to include(k)
+        end
+      end
+    end
+  end
+
+  describe 'GET /v2/graph_data/{metric}' do
+    %w[hashrate temperature availability].each do |metric|
+      it "#{metric} declares fields and data" do
+        schema = response_schema(openapi, "/v2/graph_data/#{metric}")
+        %w[fields data].each do |k|
+          expect(declared_properties(schema)).to include(k)
+        end
+      end
+    end
+  end
+
+  describe 'GET /v2/healthz' do
+    it 'declares status (minimum required by HttpApp#/healthz)' do
+      schema = response_schema(openapi, '/v2/healthz')
+      expect(declared_properties(schema)).to include('status')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `cgminer_monitor` as a CI-only dev dep in `Gemfile`, pinned by git tag `v1.2.0`, `require: false` so monitor stays out of manager's runtime autoload path.
- New `spec/contract/monitor_openapi_contract_spec.rb` loads the monitor-shipped OpenAPI from the installed gem dir (via `Gem::Specification.find_by_name`) and asserts that every envelope key `MonitorClient` + view-models read from `/v2/*` responses is declared — catching field rename or envelope reshape at CI time instead of at page-load time.
- `.rubocop.yml` gets an exclude for `spec/contract/**/*_spec.rb` matching the existing `spec/integration/**/*_spec.rb` pattern (contract specs describe cross-repo shape contracts, not classes).
- `CHANGELOG.md` `[Unreleased] ### Added` entry + `docs/dependencies.md` dev-dep table row.

## Scope

Scope is envelope-only:

- `/v2/miners` — `miners[].{id, host, port, available}`
- `/v2/miners/{id}/{summary,stats,devices,pools}` — `{ok, response, error}`
- `/v2/graph_data/{hashrate,temperature,availability}` — `{fields, data}`
- `/v2/healthz` — `status` (the one field manager reads)

Cgminer-payload drift inside `:response` (`SUMMARY`, `DEVS`, `MHS 5s`, etc.) is a separate concern — covered by api_client's FakeCgminer fixtures (which an upcoming ideation item will hoist into a shared test-support gem).

Bumping the `tag:` pin is a deliberate reviewable event — OpenAPI revisions on monitor surface as a pin-bump PR in manager, not as a page-load failure in production. Companion PR: `cgminer_monitor` PR #10 (merged) which fleshed out the envelope schemas + cut `v1.2.0`.

## Test plan

- [x] `bundle exec rake` — 289 examples, 0 failures (up from 280 with +9 new contract examples); rubocop clean
- [x] `Gemfile.lock` shows `cgminer_monitor (1.2.0)` under `GIT` source with `tag: v1.2.0`, not `GEM`
- [x] `bundle exec rspec spec/contract/monitor_openapi_contract_spec.rb -v` — 9 examples pass, one per endpoint family