### PR TITLE
docs: audit retention guidance + log filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- **Audit-retention docs** (`docs/logging.md` "Audit retention" section
+  + a brief README pointer). Documents the manager's stdout-only posture
+  and how to route + retain audit events via systemd journald, Docker
+  logging drivers, or a Vector / Fluent-Bit shipper. The recommended
+  audit filter is `event=admin.*` OR `event=rate_limit.exceeded` — the
+  latter catches unauthenticated 401-probing because the rate limiter
+  sits above the auth gate. No code change; the application has no file
+  sink and no runtime dependency on a log backend.
 - **Per-miner scheduled-restart window**
   (`lib/cgminer_manager/restart_*.rb`,
   `views/miner/_maintenance.haml`). New "Scheduled Restart" form on every

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Tuning env vars:
 
 Implementation is a single-Puma-process in-memory bucket (Hash + Mutex). Cluster-mode Puma deployments would need a shared store (Redis or similar) that the bundled middleware intentionally does not include.
 
+## Audit retention
+
+`cgminer_manager` emits structured JSON to stdout; durable storage, rotation, and retention are the deployer's responsibility (systemd journald, Docker logging driver, or a log shipper like Vector / Fluent-Bit). Filter audit events with `event=admin.*` OR `event=rate_limit.exceeded` — the latter catches unauthenticated 401-probing because the rate limiter sits above the auth gate. See [`docs/logging.md`](docs/logging.md#audit-retention) for systemd / Docker / Vector recipes and [`cgminer_monitor/docs/log_schema.md`](https://github.com/jramos/cgminer_monitor/blob/develop/docs/log_schema.md) for the cross-repo log contract.
+
 ## Further Reading
 
 -   [`CHANGELOG.md`](CHANGELOG.md) — release history: 1.0 Sinatra rewrite, 1.1 rich UI restoration, 1.2 admin surface restoration.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -37,3 +37,105 @@ Consumers and contributors should treat that document as the source of truth.
 3. Reuse standard keys where possible (see schema doc's "Standard keys" table). Minting a new key requires adding a row to that table.
 4. Add an entry to the schema doc's event catalog with the required + optional keys.
 5. Ship a CHANGELOG `### Changed` entry if the event is new on an existing namespace, or `### Added` if the namespace itself is new.
+
+## Audit retention
+
+`cgminer_manager` emits structured JSON to stdout (one event per line; `LOG_FORMAT=json` is the production default). **Durable storage, rotation, and retention are the deployer's responsibility** — handled by the supervisor (systemd / Docker / Kubernetes) or a log shipper, not by the application. The manager has no file sink and no runtime dependency on a log backend; the only contract is that stdout is consumed somewhere.
+
+A built-in rotating-file logger would reinvent what `journald` / `logrotate` / Docker's `json-file` driver / Vector / Fluent-Bit already do well, and create a parallel sink that complicates a single-source-of-truth log pipeline. The application stays narrow; the operator picks the routing.
+
+### What counts as audit-relevant
+
+For audit retention specifically (a stricter set than ops logging), filter on:
+
+- `event` matches `admin.*` — every admin POST. Includes `admin.command`, `admin.result`, `admin.auth_failed`, `admin.auth_misconfigured`, `admin.scope_rejected`, `admin.raw_command`, and the maintenance-schedule edits (`admin.maintenance.updated`, `admin.maintenance.invalid`). Each entry carries `request_id` (correlates the command emit with its result), `session_id_hash` (12-hex-char SHA256 prefix; never the raw session id), `user` (Basic-Auth username), `remote_ip` (post-`X-Forwarded-For` trust walk), and `user_agent`.
+- `event == "rate_limit.exceeded"` — the 401-probing throttle. The rate limiter sits **above** the auth gate (so an unauthenticated attacker is throttled before `AdminAuth` ever runs); auditing this event captures who was hitting your admin surface even before they gave up. Carries `remote_ip`, `path`, `retry_after`.
+
+The recommended audit-shipper filter is `event matches "admin.*" OR event == "rate_limit.exceeded"`. A filter that omits `rate_limit.exceeded` loses half the attacker-detection signal.
+
+### Recipe: systemd + journald
+
+Simplest setup if the manager runs as a systemd unit. `StandardOutput=journal` plus journald's own retention controls is enough for a single-host deployment.
+
+```ini
+# /etc/systemd/system/cgminer_manager.service (excerpt)
+[Service]
+ExecStart=/usr/local/bin/bundle exec bin/cgminer_manager run
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cgminer_manager
+```
+
+Cap the journal's per-unit storage via a drop-in:
+
+```ini
+# /etc/systemd/journald.conf.d/cgminer_manager.conf
+[Journal]
+SystemMaxUse=2G
+MaxFileSec=1week
+```
+
+Audit query (last month):
+
+```sh
+journalctl -u cgminer_manager --since '1 month ago' -o json \
+  | jq 'select(.MESSAGE | fromjson? | (.event | startswith("admin.")) or .event == "rate_limit.exceeded")'
+```
+
+### Recipe: Docker / Compose logging driver
+
+Docker's default `json-file` driver writes to `/var/lib/docker/containers/<id>/<id>-json.log` **unbounded** unless capped. Cap it via the compose service's `logging:` block:
+
+```yaml
+# docker-compose.yml (excerpt)
+services:
+  cgminer_manager:
+    image: cgminer_manager:latest
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "10"
+        # OR: redirect to journald, syslog, fluentd, etc.
+```
+
+For audit retention specifically, **prefer a long-lived shipper** (Vector / Fluent-Bit / Promtail) over relying on the json-file driver alone — `docker logs` is host-local and doesn't survive a container removal, which is not a property you want for a compliance-driven audit trail.
+
+### Recipe: Vector / Fluent-Bit sidecar
+
+Forward only audit events to a durable store. Vector example:
+
+```toml
+[sources.cgminer_manager]
+type = "docker_logs"
+include_containers = ["cgminer_manager"]
+
+[transforms.parse]
+type = "remap"
+inputs = ["cgminer_manager"]
+source = '''
+  . = parse_json!(.message)
+'''
+
+[transforms.audit_only]
+type = "filter"
+inputs = ["parse"]
+condition = '''
+  starts_with!(.event, "admin.") || .event == "rate_limit.exceeded"
+'''
+
+[sinks.audit_archive]
+type = "aws_s3"  # or loki, elasticsearch, file, etc.
+inputs = ["audit_only"]
+bucket = "my-audit-bucket"
+region = "us-east-1"
+encoding.codec = "json"
+# ... retention / lifecycle policy on the bucket / index ...
+```
+
+The same shape works in Fluent-Bit (`filter grep` on the `event` key) and Promtail (`pipeline_stages` with `match`).
+
+### Cross-references
+
+- Full event catalog and standard-key types: [`cgminer_monitor/docs/log_schema.md`](https://github.com/jramos/cgminer_monitor/blob/develop/docs/log_schema.md). Manager's events conform to that contract.
+- `request_id` correlation pattern (so an audit query can pivot from `admin.command` to its `admin.result`): same doc's "Standard keys" section.


### PR DESCRIPTION
## Summary

- New \`## Audit retention\` section in \`docs/logging.md\` with systemd / Docker / Vector recipes.
- Brief subsection in \`README.md\` linking to it.
- CHANGELOG \`[Unreleased] ### Added\` entry.

## Why docs-only

A built-in rotating-file logger would reinvent what journald / logrotate / Docker's json-file driver / Vector already do well, and create a parallel sink that complicates a single-source-of-truth log pipeline. The application stays stdout-only; the operator picks the routing.

## Audit filter

\`event=admin.*\` OR \`event=rate_limit.exceeded\` — the latter is included because the rate limiter sits ABOVE the auth gate, so it counts unauthenticated 401-probing too. A filter that omits \`rate_limit.exceeded\` would lose half the attacker-detection signal.

## Test plan

- [x] CI green (rubocop + 358 specs unchanged; this is docs-only).
- [x] \`script/validate_mermaid\` green (14/14 blocks; no Mermaid blocks touched).
- [x] Manual: sanity-checked the Vector TOML and the systemd unit example parse.