### PR TITLE
E2E: assert request_id propagates from manager into monitor logs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
       monitor_ref:
         description: 'cgminer_monitor ref to build (branch, tag, or SHA)'
         required: false
-        default: 'v1.3.1'
+        default: 'v1.3.2'
   repository_dispatch:
     types: [cgminer-contract-change]
 
@@ -27,7 +27,7 @@ jobs:
       - name: Clone cgminer_monitor
         run: |
           git clone --depth 1 \
-            --branch "${{ inputs.monitor_ref || 'v1.3.1' }}" \
+            --branch "${{ inputs.monitor_ref || 'v1.3.2' }}" \
             https://github.com/jramos/cgminer_monitor.git \
             _e2e_build/cgminer_monitor
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,10 +54,14 @@ jobs:
 
       - name: Dump compose state on failure
         if: failure()
+        env:
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
         run: |
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml ps
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml logs
 
       - name: Tear down
         if: always()
+        env:
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Compose up
         env:
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use-padded-to-64-bytes-aaaaaaa' }}
         run: |
           docker compose \
             -f docker-compose.yml \
@@ -55,7 +55,7 @@ jobs:
       - name: Dump compose state on failure
         if: failure()
         env:
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use-padded-to-64-bytes-aaaaaaa' }}
         run: |
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml ps
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml logs
@@ -63,5 +63,5 @@ jobs:
       - name: Tear down
         if: always()
         env:
-          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use' }}
+          SESSION_SECRET: ${{ secrets.E2E_SESSION_SECRET || 'e2e-ephemeral-secret-not-for-prod-use-padded-to-64-bytes-aaaaaaa' }}
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
       monitor_ref:
         description: 'cgminer_monitor ref to build (branch, tag, or SHA)'
         required: false
-        default: 'master'
+        default: 'v1.3.1'
   repository_dispatch:
     types: [cgminer-contract-change]
 
@@ -27,7 +27,7 @@ jobs:
       - name: Clone cgminer_monitor
         run: |
           git clone --depth 1 \
-            --branch "${{ inputs.monitor_ref || 'master' }}" \
+            --branch "${{ inputs.monitor_ref || 'v1.3.1' }}" \
             https://github.com/jramos/cgminer_monitor.git \
             _e2e_build/cgminer_monitor
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GIT
-  remote: https://github.com/jramos/cgminer_monitor.git
-  revision: 4c291b66f1196b3d4f181033081147168b8cfe2c
-  tag: v1.2.0
+  remote: https://github.com/jramos/cgminer_api_client.git
+  revision: 64ac716ed5c2abcebc89d591802210fe89cebf39
+  tag: v0.4.0
   specs:
-    cgminer_monitor (1.2.0)
-      cgminer_api_client (~> 0.3.0)
+    cgminer_api_client (0.4.0)
+
+GIT
+  remote: https://github.com/jramos/cgminer_monitor.git
+  revision: add311ab648b965a66523c8736eb1f77e2bcbbfa
+  tag: v1.3.1
+  specs:
+    cgminer_monitor (1.3.1)
+      cgminer_api_client (>= 0.3, < 0.5)
       mongoid (~> 9.0)
       puma (>= 6.0)
       rack-cors (~> 2.0)
@@ -20,8 +27,8 @@ GIT
 PATH
   remote: .
   specs:
-    cgminer_manager (1.5.0)
-      cgminer_api_client (~> 0.3)
+    cgminer_manager (1.6.0)
+      cgminer_api_client (~> 0.4)
       haml (~> 6.3)
       http (~> 5.2)
       puma (~> 6.4)
@@ -58,7 +65,6 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
-    cgminer_api_client (0.3.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
@@ -226,6 +232,7 @@ PLATFORMS
 DEPENDENCIES
   brakeman (>= 7.0)
   bundler-audit (>= 0.9)
+  cgminer_api_client!
   cgminer_manager!
   cgminer_monitor!
   cgminer_test_support!
@@ -249,9 +256,9 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
-  cgminer_api_client (0.3.0) sha256=89a7cbec7b66338a3b21d71967b4e42b3f9f1fafacc2ded58263a8127d98876e
-  cgminer_manager (1.5.0)
-  cgminer_monitor (1.2.0)
+  cgminer_api_client (0.4.0)
+  cgminer_manager (1.6.0)
+  cgminer_monitor (1.3.1)
   cgminer_test_support (0.1.0)
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/bin/cgminer_manager
+++ b/bin/cgminer_manager
@@ -1,6 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# Force line-buffered stdout/stderr so docker compose logs sees output
+# in real time. Without this, Ruby's default block-buffered mode (when
+# stdio is not a TTY, as in docker) holds emitted log lines until the
+# buffer fills — which for an intermittently-logging admin surface can
+# be minutes or never. Monitor's poll loop happens to keep its buffer
+# flowing, masking the same issue there.
+$stdout.sync = true
+$stderr.sync = true
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cgminer_manager'
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -28,16 +28,27 @@ services:
   fake1: &fake
     image: ruby:3.4-slim
     working_dir: /app
-    volumes:
-      - ./spec/support:/app/spec/support:ro
+    # FakeCgminer + Fixtures live in the cgminer_test_support gem since
+    # PR #4.1's extraction. Install the gem at container start (cheap —
+    # the gem is stdlib-only with no native extensions) and run a tiny
+    # ruby one-liner that binds 0.0.0.0:4028. The exe inside the gem
+    # binds 127.0.0.1 only, which is loopback-only inside the container
+    # and unreachable from the monitor service over the compose network.
     command:
-      - "ruby"
-      - "-r"
-      - "/app/spec/support/cgminer_fixtures.rb"
-      - "-r"
-      - "/app/spec/support/fake_cgminer.rb"
-      - "-e"
-      - "FakeCgminer.with(port: 4028, host: '0.0.0.0') { |p| puts p; sleep }"
+      - "bash"
+      - "-c"
+      - |
+        apt-get update -qq && apt-get install -y -qq git >/dev/null
+        cat > /tmp/Gemfile <<'GEMFILE'
+        source "https://rubygems.org"
+        gem "cgminer_test_support",
+            git: "https://github.com/jramos/cgminer_test_support.git",
+            tag: "v0.1.0"
+        GEMFILE
+        cd /tmp
+        bundle install --quiet
+        exec bundle exec ruby -r cgminer_test_support -e \
+          "CgminerTestSupport::FakeCgminer.new(host: '0.0.0.0', port: 4028).start; puts '0.0.0.0:4028'; sleep"
     healthcheck:
       test:
         - "CMD"

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -113,21 +113,21 @@ echo_id_mon=$(curl -sS -i \
 [[ "$echo_id_mon" == "$REQUEST_ID" ]] \
   || fail "monitor response did not echo X-Cgminer-Request-Id (got: '$echo_id_mon', expected '$REQUEST_ID')"
 
-# Scrape container stdout for the request_id. compose service names are
-# 'cgminer_manager' and 'cgminer_monitor' per docker-compose.yml.
+# Scrape container stdout for the request_id. Compose service names
+# are 'manager' and 'monitor' per docker-compose.yml.
 mgr_hits=$(docker compose \
   -f docker-compose.yml -f docker-compose.e2e.yml \
-  logs cgminer_manager 2>/dev/null \
+  logs manager 2>/dev/null \
   | grep -cF "$REQUEST_ID" || true)
 mon_hits=$(docker compose \
   -f docker-compose.yml -f docker-compose.e2e.yml \
-  logs cgminer_monitor 2>/dev/null \
+  logs monitor 2>/dev/null \
   | grep -cF "$REQUEST_ID" || true)
 
 [[ "$mgr_hits" -gt 0 ]] \
-  || fail "no $REQUEST_ID hits in cgminer_manager logs"
+  || fail "no $REQUEST_ID hits in manager logs"
 [[ "$mon_hits" -gt 0 ]] \
-  || fail "no $REQUEST_ID hits in cgminer_monitor logs (manager → monitor propagation broken)"
+  || fail "no $REQUEST_ID hits in monitor logs (manager → monitor propagation broken)"
 
 echo "  manager log hits: $mgr_hits"
 echo "  monitor log hits: $mon_hits"

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -86,4 +86,50 @@ for verb in version stats; do
   [[ "$code" == "200" ]] || fail "POST /manager/admin/$verb returned $code"
 done
 
+# --- Phase 4: trace-id propagation ------------------------------------------
+# An admin POST with a known X-Cgminer-Request-Id must surface the same id
+# in both manager logs (admin.command, admin.result, monitor.call,
+# cgminer.wire — though cgminer.wire is debug-level, so default-info CI runs
+# won't see it) and monitor logs (http.request from manager-driven calls).
+echo "== Phase 4: trace-id propagation =="
+
+REQUEST_ID="e2e-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+# Issue an admin POST with the trace id. The response should also echo it.
+echo "  request_id: $REQUEST_ID"
+echo_id=$(curl -sS -i \
+  -u "$ADMIN_USER:$ADMIN_PASSWORD" \
+  -H "X-Cgminer-Request-Id: $REQUEST_ID" \
+  -X POST "$MANAGER/manager/admin/version" \
+  | awk -F': ' '/^[Xx]-[Cc]gminer-[Rr]equest-[Ii]d:/ { gsub(/[\r\n]/, "", $2); print $2 }')
+[[ "$echo_id" == "$REQUEST_ID" ]] \
+  || fail "manager response did not echo X-Cgminer-Request-Id (got: '$echo_id', expected '$REQUEST_ID')"
+
+# Direct monitor call with the same header — monitor's response must echo too.
+echo_id_mon=$(curl -sS -i \
+  -H "X-Cgminer-Request-Id: $REQUEST_ID" \
+  "$MONITOR/v2/healthz" \
+  | awk -F': ' '/^[Xx]-[Cc]gminer-[Rr]equest-[Ii]d:/ { gsub(/[\r\n]/, "", $2); print $2 }')
+[[ "$echo_id_mon" == "$REQUEST_ID" ]] \
+  || fail "monitor response did not echo X-Cgminer-Request-Id (got: '$echo_id_mon', expected '$REQUEST_ID')"
+
+# Scrape container stdout for the request_id. compose service names are
+# 'cgminer_manager' and 'cgminer_monitor' per docker-compose.yml.
+mgr_hits=$(docker compose \
+  -f docker-compose.yml -f docker-compose.e2e.yml \
+  logs cgminer_manager 2>/dev/null \
+  | grep -cF "$REQUEST_ID" || true)
+mon_hits=$(docker compose \
+  -f docker-compose.yml -f docker-compose.e2e.yml \
+  logs cgminer_monitor 2>/dev/null \
+  | grep -cF "$REQUEST_ID" || true)
+
+[[ "$mgr_hits" -gt 0 ]] \
+  || fail "no $REQUEST_ID hits in cgminer_manager logs"
+[[ "$mon_hits" -gt 0 ]] \
+  || fail "no $REQUEST_ID hits in cgminer_monitor logs (manager → monitor propagation broken)"
+
+echo "  manager log hits: $mgr_hits"
+echo "  monitor log hits: $mon_hits"
+
 echo "OK: all smoke assertions passed"

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -114,15 +114,24 @@ echo_id_mon=$(curl -sS -i \
   || fail "monitor response did not echo X-Cgminer-Request-Id (got: '$echo_id_mon', expected '$REQUEST_ID')"
 
 # Scrape container stdout for the request_id. Compose service names
-# are 'manager' and 'monitor' per docker-compose.yml.
-mgr_hits=$(docker compose \
-  -f docker-compose.yml -f docker-compose.e2e.yml \
-  logs manager 2>/dev/null \
-  | grep -cF "$REQUEST_ID" || true)
-mon_hits=$(docker compose \
-  -f docker-compose.yml -f docker-compose.e2e.yml \
-  logs monitor 2>/dev/null \
-  | grep -cF "$REQUEST_ID" || true)
+# are 'manager' and 'monitor' per docker-compose.yml. Docker's log
+# file lags Ruby's stdout flush; poll briefly so we don't fail on a
+# 200-millisecond race between the http after-filter writing the
+# log line and docker capturing it.
+mgr_hits=0
+mon_hits=0
+for _ in $(seq 1 10); do
+  mgr_hits=$(docker compose \
+    -f docker-compose.yml -f docker-compose.e2e.yml \
+    logs manager 2>/dev/null \
+    | grep -cF "$REQUEST_ID" || true)
+  mon_hits=$(docker compose \
+    -f docker-compose.yml -f docker-compose.e2e.yml \
+    logs monitor 2>/dev/null \
+    | grep -cF "$REQUEST_ID" || true)
+  [[ "$mgr_hits" -gt 0 && "$mon_hits" -gt 0 ]] && break
+  sleep 0.5
+done
 
 [[ "$mgr_hits" -gt 0 ]] \
   || fail "no $REQUEST_ID hits in manager logs"


### PR DESCRIPTION
Phase 4 of the trace-id propagation work. Extends `test/e2e/smoke.sh` with assertions that prove the contract end-to-end through the real Docker stack.

## What it asserts

1. **Response-header echo on manager** — admin POST with `X-Cgminer-Request-Id: e2e-<uuid>` gets the same value back in the response header.
2. **Response-header echo on monitor** — direct GET to monitor's `/v2/healthz` with the same header echoes it back.
3. **Cross-repo log correlation** — `grep`s both `cgminer_manager` and `cgminer_monitor` container stdout for the request_id; both must have hits. This is the headline assertion: it proves the manager's `MonitorClient` actually forwards `X-Cgminer-Request-Id` on its outbound `/v2/*` calls AND that monitor's `RequestId` middleware extracts it AND that monitor's `http.request` after-filter logs it.

## Workflow change

Bumped `monitor_ref` default from `master` to `v1.3.1`. Monitor's master is currently at v1.2.0 (no `RequestId` middleware), so the trace-id assertions would fail against it. Pinning to `v1.3.1` (the released stable tag with the propagation contract) is the right shape — when monitor's master catches up on the next release-train cut, the pin can move to whatever the new stable tag is.

## Test plan

- [x] `bash -n smoke.sh` clean (syntactically valid)
- [x] `shellcheck smoke.sh` clean (one autocorrected SC2126 — `grep | wc -l` → `grep -c`)
- [ ] Workflow dispatch run after merge, asserting all 4 phases pass
EOF
)