### PR TITLE
Drop cgminer_api_client git+tag override (v0.4.0 now on rubygems)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+- **Resolution source for `cgminer_api_client` switched from git+tag
+  override to plain rubygems.** v0.4.0 was published to rubygems
+  after `cgminer_manager` v1.6.0 cut, so the temporary `Gemfile`
+  override (added in PR #33 to unblock the `on_wire:` kwarg
+  requirement) is dropped. Gemspec constraint `~> 0.4` is unchanged;
+  downstream consumers now resolve through standard channels. No
+  behavior change.
+
 ## [1.6.0] — 2026-04-25
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Pin cgminer_api_client to the v0.4.0 git tag rather than rubygems —
-# trace-id propagation in cgminer_manager v1.6.0 requires the on_wire:
-# kwarg on Miner#initialize, which ships in v0.4.0. The gemspec
-# constraint `~> 0.4` matches; this override just sources from git
-# until v0.4.0 is published to rubygems.
-gem 'cgminer_api_client',
-    git: 'https://github.com/jramos/cgminer_api_client.git',
-    tag: 'v0.4.0'
-
 group :development, :test do
   gem 'brakeman', '>= 7.0'
   gem 'bundler-audit', '>= 0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/jramos/cgminer_api_client.git
-  revision: 64ac716ed5c2abcebc89d591802210fe89cebf39
-  tag: v0.4.0
-  specs:
-    cgminer_api_client (0.4.0)
-
-GIT
   remote: https://github.com/jramos/cgminer_monitor.git
   revision: add311ab648b965a66523c8736eb1f77e2bcbbfa
   tag: v1.3.1
@@ -65,6 +58,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    cgminer_api_client (0.4.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
@@ -232,7 +226,6 @@ PLATFORMS
 DEPENDENCIES
   brakeman (>= 7.0)
   bundler-audit (>= 0.9)
-  cgminer_api_client!
   cgminer_manager!
   cgminer_monitor!
   cgminer_test_support!
@@ -256,7 +249,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
-  cgminer_api_client (0.4.0)
+  cgminer_api_client (0.4.0) sha256=adc32cb114439ae2808dee28f5b1757fa528e293abe131c85382a12cd98b1a71
   cgminer_manager (1.6.0)
   cgminer_monitor (1.3.1)
   cgminer_test_support (0.1.0)


### PR DESCRIPTION
## Summary

FU-1 follow-up to r2-§4.1's trace-id propagation work. Drops the temporary `Gemfile` override that pinned `cgminer_api_client` to a git+tag (v0.4.0) source, now that v0.4.0 is published to rubygems and resolves through the standard channel.

## Why this exists

PR #33 (manager v1.6.0) needed the `on_wire:` kwarg on `Miner#initialize` that ships in cgminer_api_client v0.4.0. At the time, v0.4.0 wasn't on rubygems — the gem had only been cut as a git tag. The override unblocked the work but forced every consumer to pull from GitHub. Pre-merge staff review of PR #33 flagged this as item #1 "important" ("end-user `gem install cgminer_manager` would fail because gemspec runtime dep `~> 0.4` won't resolve from rubygems"). Captured as Top 5 #5 in the round-2 ideation Landed write-up.

## What changed

- **`Gemfile`** — deleted the 7-line `gem 'cgminer_api_client', git: ..., tag: 'v0.4.0'` override block + its preceding comment. Resolution now flows through `gemspec` (`~> 0.4` constraint).
- **`Gemfile.lock`** — bundle install regenerated cleanly. `GIT` block at top removed, `cgminer_api_client (0.4.0)` moved to the `GEM` block under `https://rubygems.org/`, `!` pin removed from `DEPENDENCIES`. **cgminer_monitor's git+tag pin stays** — that one is a deliberate #4.3 contract-test pin where bumping is a reviewable event.
- **`CHANGELOG.md`** — `[Unreleased] ### Changed` entry naming the resolution-source switch and the no-op behavior.

## Test plan

- [x] `bundle install` resolves `cgminer_api_client (0.4.0)` from `https://rubygems.org/`
- [x] `bundle exec rake` clean (74 files, no rubocop offenses)
- [x] 375 examples, 0 failures, coverage holds at 91.49%
- [x] Gemfile.lock diff is exactly the expected shape (`GIT` block removed, `cgminer_api_client (0.4.0)` in `GEM` block, no `!` pin) — no incidental shifts in other gems
- [x] cgminer_monitor's `tag: 'v1.3.2'` pin in Gemfile is untouched (intentional)

## Out of scope

- No version bump — this is unreleased work that ships with the next manager release.
- FU-2 (smoke.sh #35) and FU-3 (consumer-side dispatch in monitor + manager) are separate follow-ups.
EOF