### PR TITLE
Phase 4 e2e: query docker logs directly + diagnostic on 0 hits (closes #35)

### DIFF
--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -113,25 +113,39 @@ echo_id_mon=$(curl -sS -i \
 [[ "$echo_id_mon" == "$REQUEST_ID" ]] \
   || fail "monitor response did not echo X-Cgminer-Request-Id (got: '$echo_id_mon', expected '$REQUEST_ID')"
 
-# Scrape container stdout for the request_id. Compose service names
-# are 'manager' and 'monitor' per docker-compose.yml. Docker's log
-# file lags Ruby's stdout flush; poll briefly so we don't fail on a
-# 200-millisecond race between the http after-filter writing the
-# log line and docker capturing it.
+# Scrape container stdout for the request_id. Use `docker logs
+# <container>` directly rather than `docker compose logs <service>` —
+# issue #35 reported the compose service-filter form returning 0 hits
+# during the polling window despite the log line being present in the
+# unfiltered output. Container names follow docker-compose's
+# project-prefix convention: <project>-<service>-<replica>.
+# Docker's log file lags Ruby's stdout flush; poll briefly so we
+# don't fail on the few-hundred-ms race between the http after-filter
+# writing the line and docker capturing it.
+MGR_CONTAINER="cgminer_manager-manager-1"
+MON_CONTAINER="cgminer_manager-monitor-1"
+
 mgr_hits=0
 mon_hits=0
 for _ in $(seq 1 10); do
-  mgr_hits=$(docker compose \
-    -f docker-compose.yml -f docker-compose.e2e.yml \
-    logs manager 2>/dev/null \
-    | grep -cF "$REQUEST_ID" || true)
-  mon_hits=$(docker compose \
-    -f docker-compose.yml -f docker-compose.e2e.yml \
-    logs monitor 2>/dev/null \
-    | grep -cF "$REQUEST_ID" || true)
+  mgr_hits=$(docker logs "$MGR_CONTAINER" 2>&1 | grep -cF "$REQUEST_ID" || true)
+  mon_hits=$(docker logs "$MON_CONTAINER" 2>&1 | grep -cF "$REQUEST_ID" || true)
   [[ "$mgr_hits" -gt 0 && "$mon_hits" -gt 0 ]] && break
   sleep 0.5
 done
+
+# Diagnostic: if either side still has 0 hits after polling, dump
+# the relevant container's last 50 stdout lines to stderr so the
+# next failing run surfaces what was actually queried instead of
+# just "0 hits" (issue #35's original symptom).
+if [[ "$mgr_hits" -eq 0 ]]; then
+  echo "DIAG: $MGR_CONTAINER last 50 stdout lines:" >&2
+  docker logs --tail 50 "$MGR_CONTAINER" 2>&1 >&2 || true
+fi
+if [[ "$mon_hits" -eq 0 ]]; then
+  echo "DIAG: $MON_CONTAINER last 50 stdout lines:" >&2
+  docker logs --tail 50 "$MON_CONTAINER" 2>&1 >&2 || true
+fi
 
 [[ "$mgr_hits" -gt 0 ]] \
   || fail "no $REQUEST_ID hits in manager logs"


### PR DESCRIPTION
## Summary

Fixes [issue #35](https://github.com/jramos/cgminer_manager/issues/35) — `docker compose logs manager` returned 0 hits during the smoke's polling window despite the log line being present in the unfiltered failure-dump 6 seconds later.

## Root cause

The compose service-filter form (`docker compose -f ... -f ... logs manager`) and the unfiltered form (`docker compose -f ... -f ... logs`) returned different views of recent stdout in our docker-compose version. The unfiltered form saw the line; the filtered form didn't. Eight e2e iterations verified the contract is correct (run #6 + #8 dumps showed the request_id propagating across 13+ events) — only the smoke's view of those events was broken.

## Fix

1. **Switch to direct `docker logs <container>`** — bypasses compose's service-filter layer entirely. Container names follow docker-compose's project-prefix convention (`cgminer_manager-manager-1`, `cgminer_manager-monitor-1`). The project name defaults to the working directory.

2. **Diagnostic stderr-print on 0 hits** — dumps the last 50 lines from the relevant container so future failures surface what was actually queried. Was the missing piece during r2-§4.1's 8 e2e iterations: each failure required cross-referencing the workflow's separate failure-dump step to see what the manager container actually emitted.

## Test plan

- [x] `bash -n test/e2e/smoke.sh` clean
- [x] `shellcheck test/e2e/smoke.sh` clean (exit 0)
- [ ] **`gh workflow run e2e.yml` dispatched against this branch** ([run #24940226528](https://github.com/jramos/cgminer_manager/actions/runs/24940226528)) — must report 4 phases pass including Phase 4's cross-repo log-correlation grep.

## Out of scope

- No CHANGELOG entry — this is a bug fix in a non-shipped test harness, not a behavior change in the gem itself. The CHANGELOG covers `lib/` + `bin/` + `docs/` changes that consumers see; `test/` infra is internal.