### PR TITLE
Emit failed_codes count map on admin.result for log-side dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.6.1] — 2026-04-25
+
+### Added
+- **`failed_codes` field on `admin.result`** — count-by-code map
+  (e.g. `{"access_denied": 3, "connection_error": 2}`) summarizing
+  how the failed entries broke down on a fleet write/query. Always
+  present (empty `{}` when `failed_count == 0`). Populated via the
+  new `AdminLogging.code_for(error)` helper that maps any rescued
+  exception to a six-symbol vocabulary (`:access_denied`,
+  `:invalid_command`, `:unknown`, `:timeout`, `:connection_error`,
+  `:unexpected`). Operators can now alert on
+  `failed_codes.access_denied > 0` from the audit log without
+  parsing English error message substrings. `FleetQueryResult` and
+  `FleetWriteResult` both expose a new `failed_codes_count_map`
+  method that the log entry duck-types over.
+
 ### Changed
 - **Resolution source for `cgminer_api_client` switched from git+tag
   override to plain rubygems.** v0.4.0 was published to rubygems
@@ -10,6 +26,11 @@
   requirement) is dropped. Gemspec constraint `~> 0.4` is unchanged;
   downstream consumers now resolve through standard channels. No
   behavior change.
+- **Bumped `cgminer_monitor` Gemfile pin from `v1.3.1` → `v1.3.3`**
+  for the schema-extended `code` standard-key row referenced by
+  manager's `admin.result.failed_codes` field. Picks up monitor's
+  own `poll.miner_failed.code` emission too, so the contract test
+  exercises the live shape.
 
 ## [1.6.0] — 2026-04-25
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development, :test do
   # and our contract assumptions drift, the pin bump surfaces it.
   gem 'cgminer_monitor',
       git: 'https://github.com/jramos/cgminer_monitor.git',
-      tag: 'v1.3.1',
+      tag: 'v1.3.3',
       require: false
   gem 'cgminer_test_support',
       git: 'https://github.com/jramos/cgminer_test_support.git',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/jramos/cgminer_monitor.git
-  revision: add311ab648b965a66523c8736eb1f77e2bcbbfa
-  tag: v1.3.1
+  revision: 2e39114f5f317416eb6db0a2784afdf8f281d93f
+  tag: v1.3.3
   specs:
-    cgminer_monitor (1.3.1)
+    cgminer_monitor (1.3.3)
       cgminer_api_client (>= 0.3, < 0.5)
       mongoid (~> 9.0)
       puma (>= 6.0)
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: .
   specs:
-    cgminer_manager (1.6.0)
+    cgminer_manager (1.6.1)
       cgminer_api_client (~> 0.4)
       haml (~> 6.3)
       http (~> 5.2)
@@ -51,7 +51,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     brakeman (8.0.4)
       racc
     bson (5.2.0)
@@ -97,7 +97,7 @@ GEM
     http-form_data (2.3.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.3)
+    json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     llhttp-ffi (0.5.1)
@@ -245,13 +245,13 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.4.0) sha256=adc32cb114439ae2808dee28f5b1757fa528e293abe131c85382a12cd98b1a71
-  cgminer_manager (1.6.0)
-  cgminer_monitor (1.3.1)
+  cgminer_manager (1.6.1)
+  cgminer_monitor (1.3.3)
   cgminer_test_support (0.1.0)
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -278,7 +278,7 @@ CHECKSUMS
   http-cookie (1.1.4) sha256=8dd8011dedcae5f91af2671b7ba878c4a9e89f0f6384790c1f4cdd176f5e3ada
   http-form_data (2.3.0) sha256=cc4eeb1361d9876821e31d7b1cf0b68f1cf874b201d27903480479d86448a5f3
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   llhttp-ffi (0.5.1) sha256=9a25a7fc19311f691a78c9c0ac0fbf4675adbd0cca74310228fdf841018fa7bc

--- a/lib/cgminer_manager/admin_logging.rb
+++ b/lib/cgminer_manager/admin_logging.rb
@@ -42,8 +42,23 @@ module CgminerManager
         scope: scope,
         ok_count: result.ok_count,
         failed_count: result.failed_count,
+        failed_codes: result.failed_codes_count_map,
         duration_ms: ((Time.now - started_at) * 1000).round
       }
+    end
+
+    # Mirror of CgminerMonitor::Poller#code_for. Six-symbol vocabulary
+    # documented in cgminer_monitor's docs/log_schema.md `code`
+    # standard-key row. Branch ordering: ApiError-shaped errors win
+    # via the duck-typed #code Symbol guard (covers the AccessDeniedError
+    # subclass too); transport-only errors fall through to the
+    # synthesized values.
+    def code_for(error)
+      return error.code if error.respond_to?(:code) && error.code.is_a?(Symbol)
+      return :timeout if error.is_a?(CgminerApiClient::TimeoutError)
+      return :connection_error if error.is_a?(CgminerApiClient::ConnectionError)
+
+      :unexpected
     end
   end
 end

--- a/lib/cgminer_manager/fleet_query_result.rb
+++ b/lib/cgminer_manager/fleet_query_result.rb
@@ -9,5 +9,15 @@ module CgminerManager
     def ok_count     = entries.count(&:ok?)
     def failed_count = entries.count { |e| !e.ok? }
     def all_ok?      = entries.all?(&:ok?)
+
+    # Count-by-code map of failed entries for `admin.result.failed_codes`.
+    # Empty `{}` when nothing failed, so consumers can rely on the key
+    # always being present. Six-symbol vocabulary documented in
+    # cgminer_monitor's docs/log_schema.md `code` row.
+    def failed_codes_count_map
+      entries.reject(&:ok?).each_with_object(Hash.new(0)) do |entry, counts|
+        counts[CgminerManager::AdminLogging.code_for(entry.error)] += 1
+      end
+    end
   end
 end

--- a/lib/cgminer_manager/fleet_write_result.rb
+++ b/lib/cgminer_manager/fleet_write_result.rb
@@ -14,5 +14,15 @@ module CgminerManager
     def failed_count = entries.count(&:failed?)
     def all_ok?      = entries.all?(&:ok?)
     def any_failed?  = entries.any?(&:failed?)
+
+    # Count-by-code map of failed entries for `admin.result.failed_codes`.
+    # Empty `{}` when nothing failed, so consumers can rely on the key
+    # always being present. Six-symbol vocabulary documented in
+    # cgminer_monitor's docs/log_schema.md `code` row.
+    def failed_codes_count_map
+      entries.select(&:failed?).each_with_object(Hash.new(0)) do |entry, counts|
+        counts[CgminerManager::AdminLogging.code_for(entry.error)] += 1
+      end
+    end
   end
 end

--- a/lib/cgminer_manager/version.rb
+++ b/lib/cgminer_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CgminerManager
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/spec/cgminer_manager/admin_logging_spec.rb
+++ b/spec/cgminer_manager/admin_logging_spec.rb
@@ -39,8 +39,10 @@ RSpec.describe CgminerManager::AdminLogging do
   end
 
   describe '.result_log_entry' do
-    it 'pulls ok_count/failed_count off a FleetWriteResult-shaped value' do
-      result = instance_double(CgminerManager::FleetWriteResult, ok_count: 3, failed_count: 1)
+    it 'pulls ok_count/failed_count/failed_codes off a FleetWriteResult-shaped value' do
+      result = instance_double(CgminerManager::FleetWriteResult,
+                               ok_count: 3, failed_count: 1,
+                               failed_codes_count_map: { access_denied: 1 })
       started = Time.now - 0.25
       entry = described_class.result_log_entry(
         command: 'restart', scope: 'all', result: result,
@@ -52,9 +54,110 @@ RSpec.describe CgminerManager::AdminLogging do
         command: 'restart',
         scope: 'all',
         ok_count: 3,
-        failed_count: 1
+        failed_count: 1,
+        failed_codes: { access_denied: 1 }
       )
       expect(entry[:duration_ms]).to be_between(200, 2000)
+    end
+
+    it 'always emits failed_codes (empty hash when nothing failed)' do
+      result = instance_double(CgminerManager::FleetWriteResult,
+                               ok_count: 3, failed_count: 0,
+                               failed_codes_count_map: {})
+      entry = described_class.result_log_entry(
+        command: 'restart', scope: 'all', result: result,
+        started_at: Time.now, request_id: 'req-zzz'
+      )
+      expect(entry).to have_key(:failed_codes)
+      expect(entry[:failed_codes]).to eq({})
+    end
+  end
+
+  describe '.code_for' do
+    it 'returns ApiError#code Symbol verbatim (covers AccessDeniedError subclass too)' do
+      err = CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45)
+      expect(described_class.code_for(err)).to eq(:access_denied)
+    end
+
+    it 'maps a base ApiError with cgminer_code: 45 to :access_denied via api_client' do
+      err = CgminerApiClient::ApiError.new('45: Access denied', cgminer_code: 45)
+      expect(described_class.code_for(err)).to eq(:access_denied)
+    end
+
+    it 'synthesizes :timeout for CgminerApiClient::TimeoutError (no wire code available)' do
+      expect(described_class.code_for(CgminerApiClient::TimeoutError.new('connect timeout')))
+        .to eq(:timeout)
+    end
+
+    it 'synthesizes :connection_error for CgminerApiClient::ConnectionError' do
+      expect(described_class.code_for(CgminerApiClient::ConnectionError.new('refused')))
+        .to eq(:connection_error)
+    end
+
+    it 'falls through to :unexpected for any non-CgminerApiClient StandardError' do
+      expect(described_class.code_for(StandardError.new('out of left field')))
+        .to eq(:unexpected)
+    end
+
+    it 'guards against duck-typed #code methods that do not return a Symbol' do
+      stray = Struct.new(:code).new(500) # mimics e.g. an HTTP-status-bearing object
+      expect(described_class.code_for(stray)).to eq(:unexpected)
+    end
+  end
+
+  # Pins the count-map shape on both Fleet*Result types so the
+  # `admin.result.failed_codes` field is consistent across query and
+  # write commands. AdminLogging.result_log_entry duck-types over
+  # whichever it gets at the call site.
+  describe 'failed_codes_count_map shape via Fleet*Result' do
+    let(:miner) { '127.0.0.1:4028' }
+    let(:access_denied) { CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45) }
+    let(:timeout)       { CgminerApiClient::TimeoutError.new('connect timeout') }
+    let(:conn_refused)  { CgminerApiClient::ConnectionError.new('refused') }
+
+    context 'with a FleetWriteResult' do
+      def write_entry(status:, error: nil)
+        CgminerManager::FleetWriteEntry.new(miner: miner, status: status, response: nil, error: error)
+      end
+
+      it 'is empty when nothing failed' do
+        result = CgminerManager::FleetWriteResult.new(entries: [write_entry(status: :ok)])
+        expect(result.failed_codes_count_map).to eq({})
+      end
+
+      it 'aggregates a uniform fleet of access-denied failures' do
+        entries = Array.new(3) { write_entry(status: :failed, error: access_denied) }
+        result = CgminerManager::FleetWriteResult.new(entries: entries)
+        expect(result.failed_codes_count_map).to eq({ access_denied: 3 })
+      end
+
+      it 'aggregates a mixed fleet across access_denied + connection_error + timeout' do
+        entries = [
+          write_entry(status: :failed, error: access_denied),
+          write_entry(status: :failed, error: conn_refused),
+          write_entry(status: :failed, error: timeout),
+          write_entry(status: :ok)
+        ]
+        result = CgminerManager::FleetWriteResult.new(entries: entries)
+        expect(result.failed_codes_count_map).to eq(access_denied: 1, connection_error: 1, timeout: 1)
+      end
+    end
+
+    context 'with a FleetQueryResult' do
+      def query_entry(passed:, error: nil)
+        CgminerManager::FleetQueryEntry.new(miner: miner, ok: passed, response: nil, error: error)
+      end
+
+      it 'is empty when nothing failed' do
+        result = CgminerManager::FleetQueryResult.new(entries: [query_entry(passed: true)])
+        expect(result.failed_codes_count_map).to eq({})
+      end
+
+      it 'aggregates a uniform fleet of access-denied failures' do
+        entries = Array.new(3) { query_entry(passed: false, error: access_denied) }
+        result = CgminerManager::FleetQueryResult.new(entries: entries)
+        expect(result.failed_codes_count_map).to eq({ access_denied: 3 })
+      end
     end
   end
 end

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -233,6 +233,41 @@ RSpec.describe 'admin surface', type: :integration do
       expect(result_event[:scope]).to eq('all')
     end
 
+    it 'emits admin.result with failed_codes count map when miners refuse the command' do
+      # Re-stub the backing fake to surface "45: Access denied" on restart so
+      # FleetWriteResult sees a real ApiError → :access_denied at code_for.
+      denied_fake = restub_fake_with(restart: CgminerTestSupport::Fixtures::PRIVILEGED_DENIED)
+
+      events = capture_admin_log_events { post_admin_command(:restart) }
+
+      result_event = events.find { |e| e[:event] == 'admin.result' }
+      expect(result_event).not_to be_nil
+      expect(result_event[:failed_count]).to be >= 1
+      expect(result_event[:failed_codes]).to eq(access_denied: result_event[:failed_count])
+    ensure
+      denied_fake&.stop
+    end
+
+    def restub_fake_with(**overrides)
+      fake.stop
+      replacement = CgminerTestSupport::FakeCgminer.new(
+        responses: fake_responses.merge(overrides.transform_keys(&:to_s))
+      ).start
+      path = File.join(Dir.mktmpdir, 'miners.yml')
+      File.write(path, "- host: 127.0.0.1\n  port: #{replacement.port}\n")
+      CgminerManager::HttpApp.configure_for_test!(
+        monitor_url: 'http://localhost:9292', miners_file: path
+      )
+      replacement
+    end
+
+    def post_admin_command(command)
+      token = fetch_csrf_token
+      post "/manager/admin/#{command}",
+           { authenticity_token: token },
+           'HTTP_X_CSRF_TOKEN' => token
+    end
+
     it 'emits admin.raw_command with command + args + scope captured verbatim' do
       events = capture_admin_log_events do
         token = fetch_csrf_token


### PR DESCRIPTION
## Summary

Adds a structured `failed_codes` field on the `admin.result` audit-log event so operators can alert on `failed_codes.access_denied > 0` (or any other code) without parsing English error message substrings:

```bash
jq 'select(.failed_codes.access_denied > 0)'
```

Always present (empty `{}` when nothing failed). Six values, mapped from each failed entry's rescued exception via a new module-level `AdminLogging.code_for(error)` helper:

| code | Source |
|---|---|
| `:access_denied` / `:invalid_command` / `:unknown` | `cgminer_api_client::ApiError#code` (v0.4.0+); covers `AccessDeniedError` subclass via the duck-typed Symbol guard |
| `:timeout` | synthesized for `CgminerApiClient::TimeoutError` |
| `:connection_error` | synthesized for `CgminerApiClient::ConnectionError` |
| `:unexpected` | defensive fallback; should not occur in practice |

Both `FleetQueryResult` and `FleetWriteResult` now expose `failed_codes_count_map`; `AdminLogging.result_log_entry` duck-types over them at the call site.

Also bumps the `cgminer_monitor` Gemfile pin from `v1.3.1` → `v1.3.3` so the contract test runs against the schema-bumped monitor (which emits `code` on its own `poll.miner_failed` events).

Bumps to v1.6.1.

## Test plan

- [x] `bundle exec rake` — 388 examples / 0 failures, RuboCop clean
- [x] Unit-level coverage of `code_for` for all six values (incl. AccessDeniedError + duck-typed-Integer guard)
- [x] Unit-level coverage of `failed_codes_count_map` shape on both Fleet*Result types (empty / uniform / mixed)
- [x] Integration test exercises the live path: forces `PRIVILEGED_DENIED` on `restart`, asserts `admin.result.failed_codes == {access_denied: N}`
- [ ] CI green on full Ruby matrix + integration