### PR TITLE
Extract code_for helper into CgminerManager::ErrorCode module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [1.6.2] — 2026-04-25
+
+### Changed
+- **Extracted `code_for` helper from `AdminLogging` into a new
+  `CgminerManager::ErrorCode` module** as `.classify(error)`. The
+  helper was a generic `CgminerApiClient`-error → symbol classifier
+  with no admin-surface coupling, and `FleetQueryResult` /
+  `FleetWriteResult` reached back into `AdminLogging` purely to
+  compute a value those Data classes own. The new home decouples
+  the dependency direction. Renamed `code_for` → `classify` along
+  the way (avoids the `def for` reserved-word landmine and reads
+  more naturally next to `ApiError#code`). Internal refactor — no
+  behavior change, no log-shape change.
+
 ## [1.6.1] — 2026-04-25
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: .
   specs:
-    cgminer_manager (1.6.1)
+    cgminer_manager (1.6.2)
       cgminer_api_client (~> 0.4)
       haml (~> 6.3)
       http (~> 5.2)
@@ -250,7 +250,7 @@ CHECKSUMS
   bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.4.0) sha256=adc32cb114439ae2808dee28f5b1757fa528e293abe131c85382a12cd98b1a71
-  cgminer_manager (1.6.1)
+  cgminer_manager (1.6.2)
   cgminer_monitor (1.3.3)
   cgminer_test_support (0.1.0)
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab

--- a/lib/cgminer_manager.rb
+++ b/lib/cgminer_manager.rb
@@ -2,6 +2,7 @@
 
 require_relative 'cgminer_manager/version'
 require_relative 'cgminer_manager/errors'
+require_relative 'cgminer_manager/error_code'
 require_relative 'cgminer_manager/config'
 require_relative 'cgminer_manager/logger'
 require_relative 'cgminer_manager/monitor_client'

--- a/lib/cgminer_manager/admin_logging.rb
+++ b/lib/cgminer_manager/admin_logging.rb
@@ -46,19 +46,5 @@ module CgminerManager
         duration_ms: ((Time.now - started_at) * 1000).round
       }
     end
-
-    # Mirror of CgminerMonitor::Poller#code_for. Six-symbol vocabulary
-    # documented in cgminer_monitor's docs/log_schema.md `code`
-    # standard-key row. Branch ordering: ApiError-shaped errors win
-    # via the duck-typed #code Symbol guard (covers the AccessDeniedError
-    # subclass too); transport-only errors fall through to the
-    # synthesized values.
-    def code_for(error)
-      return error.code if error.respond_to?(:code) && error.code.is_a?(Symbol)
-      return :timeout if error.is_a?(CgminerApiClient::TimeoutError)
-      return :connection_error if error.is_a?(CgminerApiClient::ConnectionError)
-
-      :unexpected
-    end
   end
 end

--- a/lib/cgminer_manager/error_code.rb
+++ b/lib/cgminer_manager/error_code.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CgminerManager
+  # Classifies a rescued exception into a single-symbol vocabulary
+  # for log-side dispatch. cgminer_api_client::ApiError (v0.4.0+)
+  # carries its own #code Symbol; transport-layer errors don't, so
+  # synthesize a parallel symbol so consumers can `case .code`
+  # uniformly. The six values match cgminer_monitor's
+  # docs/log_schema.md `code` standard-key entry.
+  #
+  # Branch ordering: ApiError-shaped errors win via the duck-typed
+  # #code Symbol guard (covers AccessDeniedError subclass too);
+  # transport-only errors fall through to the synthesized values.
+  module ErrorCode
+    def self.classify(error)
+      return error.code if error.respond_to?(:code) && error.code.is_a?(Symbol)
+      return :timeout if error.is_a?(CgminerApiClient::TimeoutError)
+      return :connection_error if error.is_a?(CgminerApiClient::ConnectionError)
+
+      :unexpected
+    end
+  end
+end

--- a/lib/cgminer_manager/fleet_query_result.rb
+++ b/lib/cgminer_manager/fleet_query_result.rb
@@ -16,7 +16,7 @@ module CgminerManager
     # cgminer_monitor's docs/log_schema.md `code` row.
     def failed_codes_count_map
       entries.reject(&:ok?).each_with_object(Hash.new(0)) do |entry, counts|
-        counts[CgminerManager::AdminLogging.code_for(entry.error)] += 1
+        counts[CgminerManager::ErrorCode.classify(entry.error)] += 1
       end
     end
   end

--- a/lib/cgminer_manager/fleet_write_result.rb
+++ b/lib/cgminer_manager/fleet_write_result.rb
@@ -21,7 +21,7 @@ module CgminerManager
     # cgminer_monitor's docs/log_schema.md `code` row.
     def failed_codes_count_map
       entries.select(&:failed?).each_with_object(Hash.new(0)) do |entry, counts|
-        counts[CgminerManager::AdminLogging.code_for(entry.error)] += 1
+        counts[CgminerManager::ErrorCode.classify(entry.error)] += 1
       end
     end
   end

--- a/lib/cgminer_manager/version.rb
+++ b/lib/cgminer_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CgminerManager
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end

--- a/spec/cgminer_manager/admin_logging_spec.rb
+++ b/spec/cgminer_manager/admin_logging_spec.rb
@@ -73,38 +73,6 @@ RSpec.describe CgminerManager::AdminLogging do
     end
   end
 
-  describe '.code_for' do
-    it 'returns ApiError#code Symbol verbatim (covers AccessDeniedError subclass too)' do
-      err = CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45)
-      expect(described_class.code_for(err)).to eq(:access_denied)
-    end
-
-    it 'maps a base ApiError with cgminer_code: 45 to :access_denied via api_client' do
-      err = CgminerApiClient::ApiError.new('45: Access denied', cgminer_code: 45)
-      expect(described_class.code_for(err)).to eq(:access_denied)
-    end
-
-    it 'synthesizes :timeout for CgminerApiClient::TimeoutError (no wire code available)' do
-      expect(described_class.code_for(CgminerApiClient::TimeoutError.new('connect timeout')))
-        .to eq(:timeout)
-    end
-
-    it 'synthesizes :connection_error for CgminerApiClient::ConnectionError' do
-      expect(described_class.code_for(CgminerApiClient::ConnectionError.new('refused')))
-        .to eq(:connection_error)
-    end
-
-    it 'falls through to :unexpected for any non-CgminerApiClient StandardError' do
-      expect(described_class.code_for(StandardError.new('out of left field')))
-        .to eq(:unexpected)
-    end
-
-    it 'guards against duck-typed #code methods that do not return a Symbol' do
-      stray = Struct.new(:code).new(500) # mimics e.g. an HTTP-status-bearing object
-      expect(described_class.code_for(stray)).to eq(:unexpected)
-    end
-  end
-
   # Pins the count-map shape on both Fleet*Result types so the
   # `admin.result.failed_codes` field is consistent across query and
   # write commands. AdminLogging.result_log_entry duck-types over

--- a/spec/cgminer_manager/error_code_spec.rb
+++ b/spec/cgminer_manager/error_code_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CgminerManager::ErrorCode do
+  describe '.classify' do
+    it 'returns ApiError#code Symbol verbatim (covers AccessDeniedError subclass too)' do
+      err = CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45)
+      expect(described_class.classify(err)).to eq(:access_denied)
+    end
+
+    it 'maps a base ApiError with cgminer_code: 45 to :access_denied via api_client' do
+      err = CgminerApiClient::ApiError.new('45: Access denied', cgminer_code: 45)
+      expect(described_class.classify(err)).to eq(:access_denied)
+    end
+
+    it 'synthesizes :timeout for CgminerApiClient::TimeoutError (no wire code available)' do
+      expect(described_class.classify(CgminerApiClient::TimeoutError.new('connect timeout')))
+        .to eq(:timeout)
+    end
+
+    it 'synthesizes :connection_error for CgminerApiClient::ConnectionError' do
+      expect(described_class.classify(CgminerApiClient::ConnectionError.new('refused')))
+        .to eq(:connection_error)
+    end
+
+    it 'falls through to :unexpected for any non-CgminerApiClient StandardError' do
+      expect(described_class.classify(StandardError.new('out of left field')))
+        .to eq(:unexpected)
+    end
+
+    it 'guards against duck-typed #code methods that do not return a Symbol' do
+      stray = Struct.new(:code).new(500) # mimics e.g. an HTTP-status-bearing object
+      expect(described_class.classify(stray)).to eq(:unexpected)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Moves the `code_for(error)` helper out of `AdminLogging` (where it didn't belong by responsibility) and into a new `CgminerManager::ErrorCode` module exposed as `.classify(error)`.

`AdminLogging`'s class-level header documents it as "pure helpers for the admin-surface plumbing." `code_for` was neither — it's a generic `CgminerApiClient`-error → symbol classifier with no admin-surface coupling, and `FleetQueryResult` / `FleetWriteResult` reached back into `AdminLogging` purely to compute a value those Data classes own.

## Naming

Renamed `code_for` → `classify` along the way:

- `def for(error)` would have been a Ruby reserved-word parse error.
- `.for(error)` reads ambiguously next to `CgminerApiClient::ApiError#code` ("construct an ErrorCode value?").
- `.classify(error)` reads exactly like what it does.

## Scope

Internal refactor — no behavior change, no log-shape change. Two in-repo callsites (`fleet_query_result.rb`, `fleet_write_result.rb`) updated; spec coverage relocated to a dedicated `error_code_spec.rb`.

Bumps to v1.6.2 (patch).

## Test plan

- [x] `bundle exec rake` — 388 examples / 0 failures, RuboCop clean
- [x] `ruby -c lib/cgminer_manager/error_code.rb` — Syntax OK (defends against the reserved-word landmine)
- [x] `grep -rn "AdminLogging.code_for" lib/ spec/` — zero hits
- [x] `grep -rn "ErrorCode.classify" lib/` — exactly 2 hits (the two Fleet*Result callsites)
- [ ] CI green on full Ruby matrix + integration