### PR TITLE
Add per-miner drain mode (disable pool, keep diagnostics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,79 @@
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-04-26
+
+### Added
+- **Per-miner Drain mode.** Two new POST routes: `/miner/:id/maintenance/drain`
+  and `/miner/:id/maintenance/resume`. Drain calls `disablepool 0` on the
+  rig so it stops hashing but stays responsive on the cgminer API; Resume
+  calls `enablepool 0`. Drain state persists on the per-miner
+  `RestartSchedule` record (five new nullable fields: `drained`,
+  `drained_at`, `drained_by`, `auto_resume_attempt_count`,
+  `auto_resume_last_attempt_at`) and survives manager restarts. Pool
+  index 0 is the convention used elsewhere in the codebase; per-miner
+  pool-index configuration is out of scope.
+
+  Per-miner blast radius means these routes skip the v1.7.0
+  confirmation-flow gate (per the per-miner carve-out); the browser
+  `confirm()` dialog naming the auto-resume timeout is the sole UX
+  guardrail. Maintenance partial gains Drain / Resume buttons + a
+  "Currently draining since X by Y" status block when drained.
+
+- **Auto-resume timer** prevents forgotten drains. The existing
+  `RestartScheduler` thread runs a new pre-pass on each tick: any drained
+  miner whose `now - drained_at >= auto_resume_seconds` (default 3600s,
+  configurable via `CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS`) gets
+  `enablepool 0` issued and the drain state cleared. The wire call is
+  re-validated under the store's mutex so a concurrent operator Resume
+  can't race with the timer. Failure paths apply
+  exponential-with-cap backoff: attempts 2..N retry at
+  `min(60, 2^(N-1)) * 60` seconds since the last attempt, capping at 60
+  minutes; after 5 consecutive failures the scheduler emits
+  `drain.auto_resume_giving_up` once at error level then keeps retrying
+  at the cap with `drain.failed` warns.
+
+- **Scheduler skip:** drained schedules are excluded from the nightly
+  restart fire-pass via a new `return if schedule.draining?` guard.
+  Same-tick ordering means the auto-resume pass runs FIRST, so a drain
+  that has aged out into a restart window correctly fires the restart
+  on the same tick.
+
+- **Drain suppresses monitor's offline alert.** Pairs with
+  `cgminer_monitor` v1.5.0's new `RestartScheduleClient#in_drain?`
+  predicate consumed by `AlertEvaluator#populate_offline_readings`. The
+  existing `alert.suppressed_during_restart_window` event gains a
+  `cause:` Symbol field (`:restart_window` / `:drain`) — single grep
+  target for both suppression flavors.
+
+- **Four new audit events** under `drain.*`:
+  - `drain.applied` (info) — drain succeeded; logs `auto_resume_seconds`
+    (the operator's intent at drain time).
+  - `drain.resumed` (info) — drain cleared; `cause:` is `:operator`,
+    `:auto_resume`, or `:auto_resume_orphan_cleared`.
+  - `drain.failed` (warn) — wire call returned `:failed`; `cause:` is
+    `:drain`, `:resume`, or `:auto_resume`; carries `attempt_count` for
+    auto-resume backoff visibility.
+  - `drain.indeterminate` (warn) — wire call returned `:indeterminate`
+    (verification timed out — operator should verify rig state).
+
+  Plus `drain.auto_resume_giving_up` (error, one-shot) after 5
+  consecutive auto-resume failures.
+
+- **`CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS`** new env var; integer
+  > 0; default 3600. ConfigError on 0/negative/garbage.
+
+### Changed
+- **`/api/v1/restart_schedules.json`** wire shape extends with the five
+  new drain fields automatically (the existing endpoint serializes
+  `RestartSchedule#to_h`). Backwards-compatible: older `cgminer_monitor`
+  versions read the additional fields harmlessly. **Drain suppression
+  requires `cgminer_monitor ≥ 1.5.0`** — older monitors will treat
+  drained rigs as offline and page the operator.
+- Maintenance schedule edit (POST `/miner/:id/maintenance`) now
+  preserves drain state across edits — the form only touches
+  `enabled`/`time_utc`; drain lives behind its own buttons.
+
 ## [1.7.0] — 2026-04-26
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: .
   specs:
-    cgminer_manager (1.7.0)
+    cgminer_manager (1.8.0)
       cgminer_api_client (~> 0.4)
       haml (~> 6.3)
       http (~> 5.2)
@@ -250,7 +250,7 @@ CHECKSUMS
   bson (5.2.0) sha256=c468c1e8a3cfa1e80531cc519a890f85586986721d8e305f83465cc36bb82608
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   cgminer_api_client (0.4.0) sha256=adc32cb114439ae2808dee28f5b1757fa528e293abe131c85382a12cd98b1a71
-  cgminer_manager (1.7.0)
+  cgminer_manager (1.8.0)
   cgminer_monitor (1.3.3)
   cgminer_test_support (0.1.0)
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab

--- a/README.md
+++ b/README.md
@@ -225,6 +225,35 @@ curl -u admin:pw -X POST 'http://localhost:3000/manager/admin/restart?auto_confi
 - **Cluster-mode Puma is unsafe.** Tokens live in a process-local store (same as RateLimiter); a worker hop between step 1 and step 2 silently drops legitimate confirmations. A boot-time warn fires when `WEB_CONCURRENCY > 1`. Single-worker deployment is the supported posture until shared-store support lands.
 - **Pool credentials are redacted in the audit log.** `manage_pools/add` actions persist URL+user+password in the in-memory entry so step 2 dispatches verbatim, but the audit-log `args` field is `"[REDACTED: pool credentials]"`. Raw `/run` args pass through unredacted (operator on the hook for what they typed).
 
+### Drain mode (1.8.0+)
+
+Stop a single rig from hashing without restarting it. Pool 0 gets disabled (`disablepool 0`); the rig stays responsive on the cgminer API for diagnosis. Resume calls `enablepool 0`. Useful for swapping a fan, investigating thermal issues, or pulling a rig for maintenance without losing accumulated runtime state.
+
+Per-miner only — fleet-wide drain is intentionally not exposed (the operator workflow that needs it is rare, and a process restart between drain and resume could leave half the fleet idle indefinitely).
+
+| Endpoint | Effect |
+|---|---|
+| `POST /miner/:id/maintenance/drain` | Calls `disablepool 0`, persists `drained: true`, browser confirm() prompts before submission |
+| `POST /miner/:id/maintenance/resume` | Calls `enablepool 0`, clears drain state |
+
+The maintenance partial on the miner detail page surfaces both buttons + a "Currently draining since X by Y" status block when drained.
+
+**Auto-resume.** The `RestartScheduler` thread runs a pre-pass each tick: any drained miner whose `now - drained_at >= CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS` (default `3600`) gets `enablepool 0` issued and the drain cleared. Wire-call failures apply exponential-with-cap backoff (60-minute cap); after 5 consecutive failures the scheduler emits `drain.auto_resume_giving_up` once at error level and keeps retrying at the cap with `drain.failed` warns. The pre-pass runs BEFORE the schedule-firing pass, so a drain that ages out into a restart window correctly fires the restart on the same tick.
+
+**Audit events** (collapsed per `cause:` discriminator):
+
+| Event | Level | Notes |
+|---|---|---|
+| `drain.applied` | info | Drain succeeded; carries `auto_resume_seconds` (operator intent at drain time) |
+| `drain.resumed` | info | Drain cleared; `cause:` is `:operator`, `:auto_resume`, or `:auto_resume_orphan_cleared` (rig removed from `miners.yml` mid-drain) |
+| `drain.failed` | warn | Wire call `:failed`; `cause:` distinguishes `:drain` / `:resume` / `:auto_resume` |
+| `drain.indeterminate` | warn | Wire call `:indeterminate` (verification timed out — operator should verify rig state) |
+| `drain.auto_resume_giving_up` | error | One-shot after 5 consecutive auto-resume failures |
+
+**Drain suppresses `cgminer_monitor`'s offline alert.** Requires `cgminer_monitor ≥ 1.5.0`; older monitors will treat drained rigs as offline and page the operator. The cross-repo wire is the existing `/api/v1/restart_schedules.json` endpoint, which auto-extends with the new drain fields.
+
+**Cluster-mode caveat.** Drain state lives in the same atomic-rename JSON file as `RestartStore` — single-Puma-process safe. Multi-worker Puma deployments may see a ~30-second propagation lag between a drain POST landing on worker B and the scheduler-running worker A's next file-read tick.
+
 ### Rate limiting
 
 As of 1.5.0, POSTs to admin + write paths (`/manager/admin/*`, `/miner/:id/admin/*`, `/manager/manage_pools`, `/miner/:id/manage_pools`) are throttled to 60 requests / 60 seconds per client IP. Anything over the limit receives `429 Too Many Requests` with a `Retry-After` header. The limiter sits above Basic Auth, so 401-probing attackers are throttled before `AdminAuth` ever runs.

--- a/lib/cgminer_manager/admin_logging.rb
+++ b/lib/cgminer_manager/admin_logging.rb
@@ -148,5 +148,66 @@ module CgminerManager
 
       args
     end
+
+    # ----- Drain mode events (v1.8.0+) -----
+    #
+    # Four collapsed audit events for the per-miner Drain / Resume
+    # flow. Three of them carry a `cause:` Symbol discriminator
+    # (:drain / :resume / :auto_resume; drain.resumed also accepts
+    # :operator and :auto_resume_orphan_cleared) so the originating
+    # caller is grep-discriminable without proliferating event names.
+    # cgminer_monitor v1.5.0+'s docs/log_schema.md catalogs them.
+
+    def drain_applied_log_entry(miner_id:, drained_at:, auto_resume_seconds:, request_id:, # rubocop:disable Metrics/ParameterLists
+                                user: nil, pool_index: 0)
+      {
+        event: 'drain.applied',
+        request_id: request_id,
+        miner_id: miner_id,
+        user: user,
+        drained_at: drained_at,
+        auto_resume_seconds: auto_resume_seconds,
+        pool_index: pool_index
+      }
+    end
+
+    def drain_resumed_log_entry(miner_id:, cause:, drained_at:, request_id: nil, # rubocop:disable Metrics/ParameterLists
+                                user: nil, pool_index: 0)
+      {
+        event: 'drain.resumed',
+        request_id: request_id,
+        miner_id: miner_id,
+        user: user,
+        cause: cause,
+        drained_at: drained_at,
+        pool_index: pool_index
+      }
+    end
+
+    def drain_failed_log_entry(miner_id:, cause:, error:, code:, request_id: nil, # rubocop:disable Metrics/ParameterLists
+                               user: nil, attempt_count: nil)
+      {
+        event: 'drain.failed',
+        request_id: request_id,
+        miner_id: miner_id,
+        user: user,
+        cause: cause,
+        error: error,
+        code: code,
+        attempt_count: attempt_count
+      }
+    end
+
+    def drain_indeterminate_log_entry(miner_id:, cause:, request_id: nil,
+                                      user: nil, pool_index: 0)
+      {
+        event: 'drain.indeterminate',
+        request_id: request_id,
+        miner_id: miner_id,
+        user: user,
+        cause: cause,
+        pool_index: pool_index
+      }
+    end
   end
 end

--- a/lib/cgminer_manager/config.rb
+++ b/lib/cgminer_manager/config.rb
@@ -23,6 +23,7 @@ module CgminerManager # rubocop:disable Metrics/ModuleLength
     :restart_schedules_file,
     :restart_scheduler_enabled,
     :require_confirm,
+    :drain_auto_resume_seconds,
     :rack_env
   ) do
     def validate!
@@ -30,6 +31,9 @@ module CgminerManager # rubocop:disable Metrics/ModuleLength
       raise ConfigError, "miners_file not found: #{miners_file}" unless File.exist?(miners_file)
       raise ConfigError, 'log_format must be json or text' unless %w[json text].include?(log_format)
       raise ConfigError, 'invalid log_level' unless %w[debug info warn error].include?(log_level)
+      unless drain_auto_resume_seconds.positive?
+        raise ConfigError, 'CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS must be > 0'
+      end
 
       self
     end
@@ -44,7 +48,7 @@ module CgminerManager # rubocop:disable Metrics/ModuleLength
   end
 
   class << Config
-    def from_env(env = ENV) # rubocop:disable Metrics/MethodLength
+    def from_env(env = ENV) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       rack_env = env.fetch('RACK_ENV', 'development')
       validate_admin_auth!(env)
       require_confirm = env['CGMINER_MANAGER_REQUIRE_CONFIRM'] != 'off'
@@ -70,6 +74,7 @@ module CgminerManager # rubocop:disable Metrics/ModuleLength
                                           'data/restart_schedules.json'),
         restart_scheduler_enabled: env['CGMINER_MANAGER_RESTART_SCHEDULER'] != 'off',
         require_confirm: require_confirm,
+        drain_auto_resume_seconds: parse_int(env, 'CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS', '3600'),
         rack_env: rack_env
       ).validate!
     end

--- a/lib/cgminer_manager/http_app.rb
+++ b/lib/cgminer_manager/http_app.rb
@@ -55,6 +55,10 @@ module CgminerManager
     # CGMINER_MANAGER_REQUIRE_CONFIRM=off. Server#configure_http_app
     # plumbs the parsed Config value here.
     set :confirmation_required,   true
+    # Drain mode auto-resume timeout (v1.8.0+); plumbed from
+    # Config#drain_auto_resume_seconds. Default mirrors the Config
+    # default for the no-Server-init test path.
+    set :drain_auto_resume_seconds, 3600
 
     # Parses miners.yml into the frozen `[host, port, label]` tuple list
     # consumed by routes. Server#configure_http_app and
@@ -574,6 +578,124 @@ module CgminerManager
         render_partial('shared/manage_pools')
       end
 
+      # Drives both POST /miner/:id/maintenance/drain and the symmetric
+      # /resume route. Calls PoolManager#disable_pool / #enable_pool on
+      # pool index 0, persists drain state on the per-miner schedule,
+      # and emits the appropriate drain.* audit event. Failure paths
+      # follow the locked plan's decision #6:
+      #   :ok           → drain persists / drain clears, drain.applied/resumed.
+      #   :failed       → drain does NOT persist (fail-open), drain.failed.
+      #   :indeterminate → drain persists OR clears anyway (fail-closed
+      #                    on drain, fail-open on resume), drain.indeterminate.
+      def dispatch_drain(miner_id, action:, existing: nil)
+        host_port = configured_miners_index[miner_id]
+        halt 404 unless host_port
+
+        pool_result = call_drain_wire(action, host_port)
+        status_kind = drain_pool_status(pool_result)
+
+        case action
+        when :drain
+          handle_drain_outcome(miner_id, status_kind, pool_result)
+        when :resume
+          handle_resume_outcome(miner_id, existing, status_kind, pool_result)
+        end
+
+        @miner_host_port      = miner_id
+        @maintenance_schedule = load_maintenance_schedule(miner_id)
+        render_partial('miner/maintenance')
+      end
+
+      def call_drain_wire(action, host_port)
+        host, port = host_port
+        miner = CgminerApiClient::Miner.new(host, port)
+        pm = PoolManager.new([miner])
+        action == :drain ? pm.disable_pool(pool_index: 0) : pm.enable_pool(pool_index: 0)
+      end
+
+      def drain_pool_status(pool_result)
+        return :failed if pool_result.entries.empty?
+        return :failed if pool_result.entries.any? { |e| e.command_status == :failed }
+        return :indeterminate if pool_result.entries.any? { |e| e.command_status == :indeterminate }
+
+        :ok
+      end
+
+      def handle_drain_outcome(miner_id, status_kind, pool_result)
+        case status_kind
+        when :ok, :indeterminate
+          # Both persist drained: true (decision #6 fail-closed on
+          # :indeterminate). On :indeterminate we additionally emit
+          # drain.indeterminate so the operator verifies rig state.
+          drained_at = Time.now.utc.iso8601(3)
+          settings.restart_store.update(miner_id) do |existing|
+            base = existing || RestartSchedule.build(miner_id: miner_id, enabled: false,
+                                                     time_utc: nil, last_restart_at: nil,
+                                                     last_scheduled_date_utc: nil)
+            base.with(drained: true, drained_at: drained_at,
+                      drained_by: env['cgminer_manager.admin_user'])
+          end
+          emit_drain_applied(miner_id, drained_at)
+          emit_drain_indeterminate(miner_id, :drain) if status_kind == :indeterminate
+        else
+          emit_drain_failed(miner_id, :drain, pool_result)
+          status 502
+        end
+      end
+
+      def handle_resume_outcome(miner_id, existing, status_kind, pool_result)
+        case status_kind
+        when :ok, :indeterminate
+          settings.restart_store.update(miner_id) do |s|
+            (s || existing).with(drained: false, drained_at: nil, drained_by: nil,
+                                 auto_resume_attempt_count: 0,
+                                 auto_resume_last_attempt_at: nil)
+          end
+          emit_drain_resumed(miner_id, existing)
+          emit_drain_indeterminate(miner_id, :resume) if status_kind == :indeterminate
+        else
+          emit_drain_failed(miner_id, :resume, pool_result)
+          status 502
+        end
+      end
+
+      def emit_drain_applied(miner_id, drained_at)
+        Logger.info(**AdminLogging.drain_applied_log_entry(
+          miner_id: miner_id, drained_at: drained_at,
+          auto_resume_seconds: settings.drain_auto_resume_seconds,
+          request_id: env['cgminer_manager.request_id'],
+          user: env['cgminer_manager.admin_user']
+        ))
+      end
+
+      def emit_drain_resumed(miner_id, existing)
+        Logger.info(**AdminLogging.drain_resumed_log_entry(
+          miner_id: miner_id, cause: :operator,
+          drained_at: existing.drained_at,
+          request_id: env['cgminer_manager.request_id'],
+          user: env['cgminer_manager.admin_user']
+        ))
+      end
+
+      def emit_drain_failed(miner_id, cause, pool_result)
+        failed = pool_result.entries.find { |e| e.command_status == :failed }
+        reason = failed&.command_reason.to_s
+        Logger.warn(**AdminLogging.drain_failed_log_entry(
+          miner_id: miner_id, cause: cause,
+          error: reason.empty? ? 'unknown' : reason, code: :unexpected,
+          request_id: env['cgminer_manager.request_id'],
+          user: env['cgminer_manager.admin_user']
+        ))
+      end
+
+      def emit_drain_indeterminate(miner_id, cause)
+        Logger.warn(**AdminLogging.drain_indeterminate_log_entry(
+          miner_id: miner_id, cause: cause,
+          request_id: env['cgminer_manager.request_id'],
+          user: env['cgminer_manager.admin_user']
+        ))
+      end
+
       # Load the schedule for one miner, or build a default-disabled
       # schedule when no store is configured (tests that don't pass
       # restart_store: into configure_for_test! still render the show
@@ -813,9 +935,17 @@ module CgminerManager
       end
 
       settings.restart_store.update(miner_id) do |existing|
+        # Preserve drain state across schedule edits — the maintenance
+        # form only touches enabled/time_utc; drain lives behind its
+        # own Drain/Resume buttons (v1.8.0+).
         new_schedule.with(
           last_restart_at: existing&.last_restart_at,
-          last_scheduled_date_utc: existing&.last_scheduled_date_utc
+          last_scheduled_date_utc: existing&.last_scheduled_date_utc,
+          drained: existing&.drained || false,
+          drained_at: existing&.drained_at,
+          drained_by: existing&.drained_by,
+          auto_resume_attempt_count: existing&.auto_resume_attempt_count || 0,
+          auto_resume_last_attempt_at: existing&.auto_resume_last_attempt_at
         )
       end
 
@@ -827,6 +957,42 @@ module CgminerManager
       @miner_host_port      = miner_id
       @maintenance_schedule = load_maintenance_schedule(miner_id)
       render_partial('miner/maintenance')
+    end
+
+    # ----- Drain mode endpoints (v1.8.0+) -----
+    # Per-miner only — fleet-wide drain is intentionally not exposed
+    # (the operator workflow that needs it is rare and risky enough to
+    # revisit separately). Per-miner blast radius means these routes
+    # skip the v1.7.0 confirmation-flow gate (per the per-miner
+    # carve-out); the browser-side confirm() dialog is the sole
+    # guardrail.
+
+    post '/miner/:miner_id/maintenance/drain' do
+      miner_id = CGI.unescape(params[:miner_id])
+      halt 404 unless miner_configured?(miner_id)
+      halt 503, 'restart store not configured' unless settings.restart_store
+
+      existing = settings.restart_store.load[miner_id]
+      if existing&.draining?
+        status 422
+        return 'miner already drained'
+      end
+
+      dispatch_drain(miner_id, action: :drain)
+    end
+
+    post '/miner/:miner_id/maintenance/resume' do
+      miner_id = CGI.unescape(params[:miner_id])
+      halt 404 unless miner_configured?(miner_id)
+      halt 503, 'restart store not configured' unless settings.restart_store
+
+      existing = settings.restart_store.load[miner_id]
+      unless existing&.draining?
+        status 422
+        return 'miner not drained'
+      end
+
+      dispatch_drain(miner_id, action: :resume, existing: existing)
     end
 
     get '/miner/:miner_id/graph_data/:metric' do

--- a/lib/cgminer_manager/http_app.rb
+++ b/lib/cgminer_manager/http_app.rb
@@ -588,7 +588,7 @@ module CgminerManager
       #   :indeterminate → drain persists OR clears anyway (fail-closed
       #                    on drain, fail-open on resume), drain.indeterminate.
       def dispatch_drain(miner_id, action:, existing: nil)
-        host_port = configured_miners_index[miner_id]
+        host_port = drain_host_port_for(miner_id)
         halt 404 unless host_port
 
         pool_result = call_drain_wire(action, host_port)
@@ -604,6 +604,14 @@ module CgminerManager
         @miner_host_port      = miner_id
         @maintenance_schedule = load_maintenance_schedule(miner_id)
         render_partial('miner/maintenance')
+      end
+
+      def drain_host_port_for(miner_id)
+        configured_miners.each do |entry|
+          host, port, = entry
+          return [host, port] if "#{host}:#{port}" == miner_id
+        end
+        nil
       end
 
       def call_drain_wire(action, host_port)

--- a/lib/cgminer_manager/http_app.rb
+++ b/lib/cgminer_manager/http_app.rb
@@ -581,7 +581,7 @@ module CgminerManager
       def load_maintenance_schedule(miner_id)
         store = settings.restart_store
         existing = store&.load&.[](miner_id)
-        existing || RestartSchedule.new(
+        existing || RestartSchedule.build(
           miner_id: miner_id, enabled: false, time_utc: nil,
           last_restart_at: nil, last_scheduled_date_utc: nil
         )

--- a/lib/cgminer_manager/restart_schedule.rb
+++ b/lib/cgminer_manager/restart_schedule.rb
@@ -9,10 +9,21 @@ module CgminerManager
     :enabled,
     :time_utc,
     :last_restart_at,
-    :last_scheduled_date_utc
+    :last_scheduled_date_utc,
+    # Drain-mode fields (v1.8.0+). All optional / nullable so existing
+    # JSON files round-trip cleanly. `drained == true` and a non-nil
+    # `drained_at` move together (validated below). `drained_by` is
+    # the admin user that issued the drain (nil under AUTH=off or for
+    # auto-resume-cleared entries). `auto_resume_attempt_count` and
+    # `auto_resume_last_attempt_at` track scheduler-side backoff.
+    :drained,
+    :drained_at,
+    :drained_by,
+    :auto_resume_attempt_count,
+    :auto_resume_last_attempt_at
   )
 
-  class RestartSchedule
+  class RestartSchedule # rubocop:disable Metrics/ClassLength
     TIME_UTC_PATTERN = /\A([01]\d|2[0-3]):[0-5]\d\z/
     DATE_UTC_PATTERN = /\A\d{4}-\d{2}-\d{2}\z/
 
@@ -24,12 +35,38 @@ module CgminerManager
         'enabled' => enabled,
         'time_utc' => time_utc,
         'last_restart_at' => last_restart_at,
-        'last_scheduled_date_utc' => last_scheduled_date_utc
+        'last_scheduled_date_utc' => last_scheduled_date_utc,
+        'drained' => drained,
+        'drained_at' => drained_at,
+        'drained_by' => drained_by,
+        'auto_resume_attempt_count' => auto_resume_attempt_count,
+        'auto_resume_last_attempt_at' => auto_resume_last_attempt_at
       }
     end
 
+    def draining?
+      drained == true
+    end
+
     class << self
-      def parse(hash)
+      # Convenience factory: takes the original 5 required fields plus
+      # nullable drain fields with sensible defaults. Production +
+      # spec callers that don't care about drain pass only the 5
+      # required ones; the drain-aware route handler in HttpApp passes
+      # all 10. Data.define itself doesn't support defaults so this
+      # wrapper centralizes the convention.
+      def build(miner_id:, enabled:, time_utc:, last_restart_at:, last_scheduled_date_utc:, # rubocop:disable Metrics/ParameterLists
+                drained: false, drained_at: nil, drained_by: nil,
+                auto_resume_attempt_count: 0, auto_resume_last_attempt_at: nil)
+        new(miner_id: miner_id, enabled: enabled, time_utc: time_utc,
+            last_restart_at: last_restart_at,
+            last_scheduled_date_utc: last_scheduled_date_utc,
+            drained: drained, drained_at: drained_at, drained_by: drained_by,
+            auto_resume_attempt_count: auto_resume_attempt_count,
+            auto_resume_last_attempt_at: auto_resume_last_attempt_at)
+      end
+
+      def parse(hash) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         raise InvalidError, "expected a Hash, got #{hash.class}" unless hash.is_a?(Hash)
 
         miner_id = hash['miner_id'] || hash[:miner_id]
@@ -37,16 +74,32 @@ module CgminerManager
         time_utc = hash['time_utc'] || hash[:time_utc]
         last_restart_at         = hash['last_restart_at'] || hash[:last_restart_at]
         last_scheduled_date_utc = hash['last_scheduled_date_utc'] || hash[:last_scheduled_date_utc]
+        drained                 = hash.fetch('drained') { hash[:drained] }
+        drained_at              = hash['drained_at'] || hash[:drained_at]
+        drained_by              = hash['drained_by'] || hash[:drained_by]
+        auto_resume_attempt_count   = hash.fetch('auto_resume_attempt_count') { hash[:auto_resume_attempt_count] }
+        auto_resume_last_attempt_at = hash['auto_resume_last_attempt_at'] || hash[:auto_resume_last_attempt_at]
+
+        # Default-on-absence (back-compat with pre-v1.8.0 JSON files).
+        drained = false if drained.nil?
+        auto_resume_attempt_count = 0 if auto_resume_attempt_count.nil?
 
         validate_miner_id!(miner_id)
         validate_enabled!(enabled)
         validate_time_utc!(time_utc, enabled: enabled)
         validate_optional_iso_string!(:last_restart_at, last_restart_at)
         validate_optional_date_utc!(last_scheduled_date_utc)
+        validate_drained!(drained, drained_at)
+        validate_optional_string!(:drained_by, drained_by)
+        validate_auto_resume_attempt_count!(auto_resume_attempt_count)
+        validate_optional_iso_string!(:auto_resume_last_attempt_at, auto_resume_last_attempt_at)
 
         new(miner_id: miner_id, enabled: enabled, time_utc: time_utc,
             last_restart_at: last_restart_at,
-            last_scheduled_date_utc: last_scheduled_date_utc)
+            last_scheduled_date_utc: last_scheduled_date_utc,
+            drained: drained, drained_at: drained_at, drained_by: drained_by,
+            auto_resume_attempt_count: auto_resume_attempt_count,
+            auto_resume_last_attempt_at: auto_resume_last_attempt_at)
       end
 
       private
@@ -88,6 +141,41 @@ module CgminerManager
         return if value.is_a?(String) && DATE_UTC_PATTERN.match?(value)
 
         raise InvalidError, "last_scheduled_date_utc must be nil or YYYY-MM-DD, got #{value.inspect}"
+      end
+
+      def validate_optional_string!(field, value)
+        return if value.nil?
+        return if value.is_a?(String) && !value.empty?
+
+        raise InvalidError, "#{field} must be nil or a non-empty string, got #{value.inspect}"
+      end
+
+      # Drain state must move atomically: drained == true requires a
+      # drained_at, and drained == false forbids one. Anything else
+      # implies operator intent didn't fully take effect (or some
+      # serializer trimmed one of the two), and we'd rather fail-loud
+      # than silently treat half-drain state as drained.
+      def validate_drained!(drained, drained_at)
+        unless [true, false].include?(drained)
+          raise InvalidError, "drained must be true or false, got #{drained.inspect}"
+        end
+
+        if drained
+          return if drained_at.is_a?(String) && !drained_at.empty?
+
+          raise InvalidError, 'drained_at must be a non-empty ISO8601 string when ' \
+                              "drained=true, got #{drained_at.inspect}"
+        end
+
+        return if drained_at.nil?
+
+        raise InvalidError, "drained_at must be nil when drained=false, got #{drained_at.inspect}"
+      end
+
+      def validate_auto_resume_attempt_count!(value)
+        return if value.is_a?(Integer) && value >= 0
+
+        raise InvalidError, "auto_resume_attempt_count must be a non-negative Integer, got #{value.inspect}"
       end
     end
   end

--- a/lib/cgminer_manager/restart_scheduler.rb
+++ b/lib/cgminer_manager/restart_scheduler.rb
@@ -16,13 +16,24 @@ module CgminerManager
     TICK_SECONDS    = 30
     WINDOW_MINUTES  = 2
 
-    def initialize(store:, configured_miners_provider:,
+    # Auto-resume backoff: attempts 2..N retry at min(60, 2^(N-1)) * 60
+    # seconds since the last attempt, capped at 60 minutes. After this
+    # many consecutive failures we emit drain.auto_resume_giving_up
+    # once at error-level, then keep retrying at the cap with warn
+    # emissions only — recoverable when the rig comes back.
+    AUTO_RESUME_GIVING_UP_AFTER = 5
+
+    def initialize(store:, configured_miners_provider:, # rubocop:disable Metrics/ParameterLists
+                   auto_resume_seconds: 3600,
                    clock: -> { Time.now.utc },
-                   miner_factory: ->(host, port) { CgminerApiClient::Miner.new(host, port) })
+                   miner_factory: ->(host, port) { CgminerApiClient::Miner.new(host, port) },
+                   pool_manager_factory: ->(miner) { PoolManager.new([miner]) })
       @store                      = store
       @configured_miners_provider = configured_miners_provider
+      @auto_resume_seconds        = auto_resume_seconds
       @clock                      = clock
       @miner_factory              = miner_factory
+      @pool_manager_factory       = pool_manager_factory
       @stopped                    = false
       @mutex                      = Mutex.new
       @cv                         = ConditionVariable.new
@@ -55,17 +66,154 @@ module CgminerManager
 
     # Run a single scheduling pass. Public so specs can drive ticks
     # synchronously without spawning the thread.
+    #
+    # The auto-resume pass runs FIRST so a drained schedule that has
+    # aged out into its restart window correctly fires the restart in
+    # the same tick: drain clears, schedule fires.
     def tick
       now           = @clock.call
-      schedules     = @store.load
       miners_by_id  = configured_miners_index
 
-      schedules.each_value do |schedule|
+      auto_resume_drained(now, miners_by_id)
+
+      @store.load.each_value do |schedule|
         process_schedule(schedule, now, miners_by_id)
       end
     end
 
     private
+
+    # Walks the store for drained schedules whose backoff window has
+    # elapsed. For each candidate, re-validates `drained == true` under
+    # the store's mutex (protects against a concurrent operator Resume
+    # winning the race) before issuing the wire call.
+    def auto_resume_drained(now, miners_by_id)
+      @store.load.each_value do |schedule|
+        next unless schedule.draining?
+        next unless auto_resume_due?(schedule, now)
+
+        miner_id = schedule.miner_id
+        host_port = miners_by_id[miner_id]
+        next force_clear_orphan_drain(miner_id) if host_port.nil?
+
+        attempt_auto_resume(miner_id, host_port, now)
+      end
+    end
+
+    # Exposed for callers that need the same backoff cadence (the
+    # scheduler's tick). `now - drained_at >= @auto_resume_seconds`
+    # is the first-attempt gate; subsequent attempts back off at
+    # min(60, 2^(N-1)) * 60 seconds since the last attempt.
+    def auto_resume_due?(schedule, now)
+      drained_at = parse_iso8601(schedule.drained_at)
+      return false if drained_at.nil?
+      return false unless (now - drained_at) >= @auto_resume_seconds
+
+      last_attempt = parse_iso8601(schedule.auto_resume_last_attempt_at)
+      return true if last_attempt.nil?
+
+      backoff_seconds = [60, 2**[schedule.auto_resume_attempt_count - 1, 0].max].min * 60
+      (now - last_attempt) >= backoff_seconds
+    end
+
+    def attempt_auto_resume(miner_id, host_port, now)
+      pool_result = nil
+      @store.update(miner_id) do |existing|
+        next existing if existing.nil? || !existing.draining?
+
+        host, port = host_port
+        miner = @miner_factory.call(host, port)
+        pool_result = @pool_manager_factory.call(miner).enable_pool(pool_index: 0)
+        next_schedule_after_auto_resume(existing, pool_result, now)
+      end
+
+      log_auto_resume_outcome(miner_id, pool_result, now) if pool_result
+    rescue StandardError => e
+      Logger.error(event: 'drain.auto_resume_persist_failed',
+                   miner_id: miner_id,
+                   error: e.class.to_s, message: e.message)
+    end
+
+    def next_schedule_after_auto_resume(schedule, pool_result, now)
+      status = pool_result_status(pool_result)
+      case status
+      when :ok, :indeterminate
+        # Both success and indeterminate clear the drain state so the
+        # next nightly restart can proceed; indeterminate operators
+        # should verify rig state but the scheduler shouldn't keep
+        # retrying a possibly-already-resumed rig.
+        schedule.with(drained: false, drained_at: nil, drained_by: nil,
+                      auto_resume_attempt_count: 0,
+                      auto_resume_last_attempt_at: nil)
+      else # :failed
+        new_count = schedule.auto_resume_attempt_count + 1
+        schedule.with(auto_resume_attempt_count: new_count,
+                      auto_resume_last_attempt_at: now.iso8601(3))
+      end
+    end
+
+    def log_auto_resume_outcome(miner_id, pool_result, now)
+      status = pool_result_status(pool_result)
+      schedule = @store.load[miner_id]
+      attempt_count = schedule&.auto_resume_attempt_count || 0
+      drained_at_iso = schedule&.drained_at # nil after :ok / :indeterminate clears
+
+      case status
+      when :ok
+        Logger.info(event: 'drain.resumed', miner_id: miner_id,
+                    cause: :auto_resume, drained_at: drained_at_iso, pool_index: 0)
+      when :indeterminate
+        Logger.warn(event: 'drain.indeterminate', miner_id: miner_id,
+                    cause: :auto_resume, pool_index: 0)
+      else # :failed
+        log_payload = pool_failed_log_payload(pool_result)
+        Logger.warn(event: 'drain.failed', miner_id: miner_id,
+                    cause: :auto_resume, attempt_count: attempt_count, **log_payload)
+        if attempt_count == AUTO_RESUME_GIVING_UP_AFTER
+          Logger.error(event: 'drain.auto_resume_giving_up',
+                       miner_id: miner_id, attempt_count: attempt_count)
+        end
+      end
+      _ = now # accepted for symmetry; unused in current emissions
+    end
+
+    def force_clear_orphan_drain(miner_id)
+      drained_at = nil
+      @store.update(miner_id) do |existing|
+        next existing if existing.nil? || !existing.draining?
+
+        drained_at = existing.drained_at
+        existing.with(drained: false, drained_at: nil, drained_by: nil,
+                      auto_resume_attempt_count: 0,
+                      auto_resume_last_attempt_at: nil)
+      end
+      Logger.info(event: 'drain.resumed', miner_id: miner_id,
+                  cause: :auto_resume_orphan_cleared,
+                  drained_at: drained_at, pool_index: 0)
+    end
+
+    def pool_result_status(pool_result)
+      entries = pool_result.entries
+      return :failed if entries.empty?
+      return :failed if entries.any? { |e| e.command_status == :failed }
+      return :indeterminate if entries.any? { |e| e.command_status == :indeterminate }
+
+      :ok
+    end
+
+    def pool_failed_log_payload(pool_result)
+      failed = pool_result.entries.find { |e| e.command_status == :failed }
+      reason = failed&.command_reason.to_s
+      { error: reason.empty? ? 'unknown' : reason, code: :unexpected }
+    end
+
+    def parse_iso8601(value)
+      return nil unless value.is_a?(String)
+
+      Time.iso8601(value)
+    rescue ArgumentError
+      nil
+    end
 
     # Thread-top guard: any uncaught exception inside the loop would
     # silently kill the scheduler. Wrap with rescue Exception (mirroring
@@ -92,6 +240,9 @@ module CgminerManager
     def process_schedule(schedule, now, miners_by_id)
       return unless schedule.enabled
       return if schedule.time_utc.nil?
+      # Drained miners skip the nightly restart; auto-resume in tick()
+      # already cleared eligible drains by this point.
+      return if schedule.draining?
 
       host_port = miners_by_id[schedule.miner_id]
       return unless host_port # orphan: schedule for a miner no longer in miners.yml

--- a/lib/cgminer_manager/restart_scheduler.rb
+++ b/lib/cgminer_manager/restart_scheduler.rb
@@ -118,8 +118,20 @@ module CgminerManager
 
     def attempt_auto_resume(miner_id, host_port, now)
       pool_result = nil
+      pre_drained_at = nil
+      pre_attempt_count = 0
       @store.update(miner_id) do |existing|
+        # Re-read inside the mutex protects against a concurrent
+        # operator Resume that won the race between candidate
+        # selection and this block (review C1).
         next existing if existing.nil? || !existing.draining?
+
+        # Capture state BEFORE the update mutates it — `drained_at`
+        # is needed in the log emission for elapsed-time calc, and
+        # the post-update store read would see nil for :ok and
+        # :indeterminate paths.
+        pre_drained_at = existing.drained_at
+        pre_attempt_count = existing.auto_resume_attempt_count
 
         host, port = host_port
         miner = @miner_factory.call(host, port)
@@ -127,7 +139,11 @@ module CgminerManager
         next_schedule_after_auto_resume(existing, pool_result, now)
       end
 
-      log_auto_resume_outcome(miner_id, pool_result, now) if pool_result
+      return unless pool_result
+
+      log_auto_resume_outcome(miner_id, pool_result,
+                              drained_at: pre_drained_at,
+                              prior_attempt_count: pre_attempt_count)
     rescue StandardError => e
       Logger.error(event: 'drain.auto_resume_persist_failed',
                    miner_id: miner_id,
@@ -152,29 +168,26 @@ module CgminerManager
       end
     end
 
-    def log_auto_resume_outcome(miner_id, pool_result, now)
+    def log_auto_resume_outcome(miner_id, pool_result, drained_at:, prior_attempt_count:)
       status = pool_result_status(pool_result)
-      schedule = @store.load[miner_id]
-      attempt_count = schedule&.auto_resume_attempt_count || 0
-      drained_at_iso = schedule&.drained_at # nil after :ok / :indeterminate clears
 
       case status
       when :ok
         Logger.info(event: 'drain.resumed', miner_id: miner_id,
-                    cause: :auto_resume, drained_at: drained_at_iso, pool_index: 0)
+                    cause: :auto_resume, drained_at: drained_at, pool_index: 0)
       when :indeterminate
         Logger.warn(event: 'drain.indeterminate', miner_id: miner_id,
                     cause: :auto_resume, pool_index: 0)
       else # :failed
+        new_count = prior_attempt_count + 1
         log_payload = pool_failed_log_payload(pool_result)
         Logger.warn(event: 'drain.failed', miner_id: miner_id,
-                    cause: :auto_resume, attempt_count: attempt_count, **log_payload)
-        if attempt_count == AUTO_RESUME_GIVING_UP_AFTER
+                    cause: :auto_resume, attempt_count: new_count, **log_payload)
+        if new_count == AUTO_RESUME_GIVING_UP_AFTER
           Logger.error(event: 'drain.auto_resume_giving_up',
-                       miner_id: miner_id, attempt_count: attempt_count)
+                       miner_id: miner_id, attempt_count: new_count)
         end
       end
-      _ = now # accepted for symmetry; unused in current emissions
     end
 
     def force_clear_orphan_drain(miner_id)

--- a/lib/cgminer_manager/server.rb
+++ b/lib/cgminer_manager/server.rb
@@ -99,7 +99,8 @@ module CgminerManager
 
       @restart_scheduler = RestartScheduler.new(
         store: @restart_store,
-        configured_miners_provider: -> { HttpApp.settings.configured_miners }
+        configured_miners_provider: -> { HttpApp.settings.configured_miners },
+        auto_resume_seconds: @config.drain_auto_resume_seconds
       )
       @restart_scheduler.start
       Logger.info(event: 'restart.scheduler.started',

--- a/lib/cgminer_manager/server.rb
+++ b/lib/cgminer_manager/server.rb
@@ -92,6 +92,7 @@ module CgminerManager
       HttpApp.set :rate_limit_window_seconds, @config.rate_limit_window_seconds
       HttpApp.set :trusted_proxies,           @config.trusted_proxies
       HttpApp.set :confirmation_required,     @config.require_confirm
+      HttpApp.set :drain_auto_resume_seconds, @config.drain_auto_resume_seconds
     end
 
     def start_restart_scheduler

--- a/lib/cgminer_manager/version.rb
+++ b/lib/cgminer_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CgminerManager
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/spec/cgminer_manager/admin_logging_spec.rb
+++ b/spec/cgminer_manager/admin_logging_spec.rb
@@ -225,6 +225,95 @@ RSpec.describe CgminerManager::AdminLogging do
   # `admin.result.failed_codes` field is consistent across query and
   # write commands. AdminLogging.result_log_entry duck-types over
   # whichever it gets at the call site.
+  describe '.drain_applied_log_entry (v1.8.0+)' do
+    it 'logs auto_resume_seconds (NOT auto_resume_at — env may change between drain and resume)' do
+      entry = described_class.drain_applied_log_entry(
+        miner_id: '127.0.0.1:4028', drained_at: '2026-04-26T12:00:00.000Z',
+        auto_resume_seconds: 3600,
+        request_id: 'req-1', user: 'op'
+      )
+      expect(entry).to include(
+        event: 'drain.applied',
+        miner_id: '127.0.0.1:4028',
+        drained_at: '2026-04-26T12:00:00.000Z',
+        auto_resume_seconds: 3600,
+        pool_index: 0,
+        user: 'op'
+      )
+    end
+  end
+
+  describe '.drain_resumed_log_entry (v1.8.0+)' do
+    it 'carries cause: :operator + the original drained_at for elapsed-time calc' do
+      entry = described_class.drain_resumed_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :operator,
+        drained_at: '2026-04-26T12:00:00.000Z',
+        request_id: 'req-2', user: 'op'
+      )
+      expect(entry).to include(
+        event: 'drain.resumed',
+        cause: :operator,
+        drained_at: '2026-04-26T12:00:00.000Z',
+        miner_id: '127.0.0.1:4028'
+      )
+    end
+
+    it 'accepts cause: :auto_resume with nil request_id + nil user (scheduler-thread emission)' do
+      entry = described_class.drain_resumed_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :auto_resume,
+        drained_at: '2026-04-26T12:00:00.000Z'
+      )
+      expect(entry).to include(cause: :auto_resume, request_id: nil, user: nil)
+    end
+
+    it 'accepts cause: :auto_resume_orphan_cleared (rig removed from miners.yml mid-drain)' do
+      entry = described_class.drain_resumed_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :auto_resume_orphan_cleared,
+        drained_at: '2026-04-26T12:00:00.000Z'
+      )
+      expect(entry[:cause]).to eq(:auto_resume_orphan_cleared)
+    end
+  end
+
+  describe '.drain_failed_log_entry (v1.8.0+)' do
+    it 'carries cause: + error + code + optional attempt_count' do
+      entry = described_class.drain_failed_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :auto_resume,
+        error: 'connect timeout', code: :timeout, attempt_count: 3
+      )
+      expect(entry).to include(
+        event: 'drain.failed',
+        cause: :auto_resume,
+        error: 'connect timeout',
+        code: :timeout,
+        attempt_count: 3
+      )
+    end
+
+    it 'leaves attempt_count nil for operator-initiated drain/resume failures' do
+      entry = described_class.drain_failed_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :drain,
+        error: 'refused', code: :connection_error,
+        request_id: 'req-1', user: 'op'
+      )
+      expect(entry[:attempt_count]).to be_nil
+    end
+  end
+
+  describe '.drain_indeterminate_log_entry (v1.8.0+)' do
+    it 'carries cause: + pool_index + nil request_id for auto_resume' do
+      entry = described_class.drain_indeterminate_log_entry(
+        miner_id: '127.0.0.1:4028', cause: :auto_resume
+      )
+      expect(entry).to include(
+        event: 'drain.indeterminate',
+        cause: :auto_resume,
+        pool_index: 0,
+        request_id: nil
+      )
+    end
+  end
+
   describe 'failed_codes_count_map shape via Fleet*Result' do
     let(:miner) { '127.0.0.1:4028' }
     let(:access_denied) { CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45) }

--- a/spec/cgminer_manager/config_spec.rb
+++ b/spec/cgminer_manager/config_spec.rb
@@ -265,6 +265,36 @@ RSpec.describe CgminerManager::Config do
     end
   end
 
+  describe '.from_env DRAIN_AUTO_RESUME_SECONDS (v1.8.0+)' do
+    it 'defaults drain_auto_resume_seconds to 3600 when unset' do
+      config = described_class.from_env(env_base)
+      expect(config.drain_auto_resume_seconds).to eq(3600)
+    end
+
+    it 'parses an explicit integer value' do
+      config = described_class.from_env(env_base.merge('CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS' => '7200'))
+      expect(config.drain_auto_resume_seconds).to eq(7200)
+    end
+
+    it 'raises ConfigError when set to 0' do
+      env = env_base.merge('CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS' => '0')
+      expect { described_class.from_env(env) }
+        .to raise_error(CgminerManager::ConfigError, /DRAIN_AUTO_RESUME_SECONDS/)
+    end
+
+    it 'raises ConfigError when set to a negative value' do
+      env = env_base.merge('CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS' => '-30')
+      expect { described_class.from_env(env) }
+        .to raise_error(CgminerManager::ConfigError, /DRAIN_AUTO_RESUME_SECONDS/)
+    end
+
+    it 'raises ConfigError when set to garbage' do
+      env = env_base.merge('CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS' => 'forever')
+      expect { described_class.from_env(env) }
+        .to raise_error(CgminerManager::ConfigError, /must be an integer/)
+    end
+  end
+
   describe '#load_miners' do
     it 'yields [host, port] pairs' do
       config = described_class.from_env(env_base)

--- a/spec/cgminer_manager/restart_schedule_spec.rb
+++ b/spec/cgminer_manager/restart_schedule_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe CgminerManager::RestartSchedule do
 
   describe '#to_h' do
     it 'returns a string-keyed hash with all fields' do
-      schedule = described_class.new(
+      schedule = described_class.build(
         miner_id: '10.0.0.1:4028', enabled: true, time_utc: '03:30',
         last_restart_at: '2026-04-24T03:30:00Z', last_scheduled_date_utc: '2026-04-24'
       )
@@ -105,16 +105,108 @@ RSpec.describe CgminerManager::RestartSchedule do
         'enabled' => true,
         'time_utc' => '03:30',
         'last_restart_at' => '2026-04-24T03:30:00Z',
-        'last_scheduled_date_utc' => '2026-04-24'
+        'last_scheduled_date_utc' => '2026-04-24',
+        'drained' => false,
+        'drained_at' => nil,
+        'drained_by' => nil,
+        'auto_resume_attempt_count' => 0,
+        'auto_resume_last_attempt_at' => nil
       )
     end
 
     it 'round-trips through parse' do
-      original = described_class.new(
+      original = described_class.build(
         miner_id: '10.0.0.1:4028', enabled: false, time_utc: nil,
         last_restart_at: nil, last_scheduled_date_utc: nil
       )
       expect(described_class.parse(original.to_h)).to eq(original)
+    end
+  end
+
+  describe 'drain mode (v1.8.0+)' do
+    let(:base) do
+      {
+        'miner_id' => '127.0.0.1:4028',
+        'enabled' => true,
+        'time_utc' => '04:00',
+        'last_restart_at' => nil,
+        'last_scheduled_date_utc' => nil
+      }
+    end
+
+    it 'defaults drained=false on .build when not specified' do
+      s = described_class.build(miner_id: 'x:4028', enabled: false, time_utc: nil,
+                                last_restart_at: nil, last_scheduled_date_utc: nil)
+      expect(s.drained).to be(false)
+      expect(s.draining?).to be(false)
+      expect(s.auto_resume_attempt_count).to eq(0)
+    end
+
+    it 'returns true from #draining? when drained=true' do
+      s = described_class.build(miner_id: 'x:4028', enabled: false, time_utc: nil,
+                                last_restart_at: nil, last_scheduled_date_utc: nil,
+                                drained: true, drained_at: '2026-04-26T12:00:00.000Z',
+                                drained_by: 'op')
+      expect(s.draining?).to be(true)
+    end
+
+    it 'parses a hash that includes the drain fields' do
+      s = described_class.parse(base.merge(
+                                  'drained' => true,
+                                  'drained_at' => '2026-04-26T12:00:00.000Z',
+                                  'drained_by' => 'admin',
+                                  'auto_resume_attempt_count' => 3,
+                                  'auto_resume_last_attempt_at' => '2026-04-26T12:01:00.000Z'
+                                ))
+      expect(s.drained).to be(true)
+      expect(s.drained_at).to eq('2026-04-26T12:00:00.000Z')
+      expect(s.drained_by).to eq('admin')
+      expect(s.auto_resume_attempt_count).to eq(3)
+      expect(s.auto_resume_last_attempt_at).to eq('2026-04-26T12:01:00.000Z')
+    end
+
+    it 'is back-compat with pre-v1.8.0 JSON files (no drain fields present)' do
+      s = described_class.parse(base)
+      expect(s.drained).to be(false)
+      expect(s.drained_at).to be_nil
+      expect(s.drained_by).to be_nil
+      expect(s.auto_resume_attempt_count).to eq(0)
+      expect(s.auto_resume_last_attempt_at).to be_nil
+    end
+
+    it 'round-trips a drained schedule through to_h + parse' do
+      original = described_class.build(
+        miner_id: 'x:4028', enabled: false, time_utc: nil,
+        last_restart_at: nil, last_scheduled_date_utc: nil,
+        drained: true, drained_at: '2026-04-26T12:00:00.000Z', drained_by: 'op',
+        auto_resume_attempt_count: 2, auto_resume_last_attempt_at: '2026-04-26T12:30:00.000Z'
+      )
+      expect(described_class.parse(original.to_h)).to eq(original)
+    end
+
+    it 'rejects drained=true with nil drained_at' do
+      expect { described_class.parse(base.merge('drained' => true, 'drained_at' => nil)) }
+        .to raise_error(described_class::InvalidError, /drained_at must be a non-empty ISO8601/)
+    end
+
+    it 'rejects drained=false with non-nil drained_at (the two must move together)' do
+      expect { described_class.parse(base.merge('drained' => false, 'drained_at' => '2026-04-26T12:00:00.000Z')) }
+        .to raise_error(described_class::InvalidError, /drained_at must be nil when drained=false/)
+    end
+
+    it 'rejects truthy-not-true drained value (defensive)' do
+      expect { described_class.parse(base.merge('drained' => 'true', 'drained_at' => '2026-04-26T12:00:00.000Z')) }
+        .to raise_error(described_class::InvalidError, /drained must be true or false/)
+    end
+
+    it 'rejects non-Integer auto_resume_attempt_count' do
+      expect { described_class.parse(base.merge('auto_resume_attempt_count' => '3')) }
+        .to raise_error(described_class::InvalidError, /auto_resume_attempt_count/)
+    end
+
+    it 'rejects negative auto_resume_attempt_count' do
+      expect { described_class.parse(base.merge('auto_resume_attempt_count' => -1)) }
+        .to raise_error(described_class::InvalidError, /auto_resume_attempt_count/)
     end
   end
 end

--- a/spec/cgminer_manager/restart_scheduler_spec.rb
+++ b/spec/cgminer_manager/restart_scheduler_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CgminerManager::RestartScheduler do
   let(:fake_miner) { instance_double(CgminerApiClient::Miner) }
   let(:fixed_now) { Time.utc(2026, 4, 24, 4, 0, 30) }
   let(:schedule) do
-    CgminerManager::RestartSchedule.new(
+    CgminerManager::RestartSchedule.build(
       miner_id: '127.0.0.1:4028', enabled: true, time_utc: '04:00',
       last_restart_at: nil, last_scheduled_date_utc: nil
     )

--- a/spec/cgminer_manager/restart_scheduler_spec.rb
+++ b/spec/cgminer_manager/restart_scheduler_spec.rb
@@ -173,6 +173,197 @@ RSpec.describe CgminerManager::RestartScheduler do
     end
   end
 
+  describe 'drain mode (v1.8.0+)' do
+    let(:pool_manager) { instance_double(CgminerManager::PoolManager) }
+    let(:scheduler) do
+      described_class.new(store: store,
+                          configured_miners_provider: -> { configured_miners },
+                          auto_resume_seconds: 60,
+                          clock: -> { fixed_now },
+                          miner_factory: ->(_h, _p) { fake_miner },
+                          pool_manager_factory: ->(_m) { pool_manager })
+    end
+
+    def ok_pool_result
+      entry = CgminerManager::PoolManager::MinerEntry.new(
+        miner: fake_miner, command_status: :ok, command_reason: nil,
+        save_status: :ok, save_reason: nil
+      )
+      CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+    end
+
+    def failed_pool_result(reason: 'connect timeout')
+      entry = CgminerManager::PoolManager::MinerEntry.new(
+        miner: fake_miner, command_status: :failed, command_reason: reason,
+        save_status: :failed, save_reason: reason
+      )
+      CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+    end
+
+    def indeterminate_pool_result
+      entry = CgminerManager::PoolManager::MinerEntry.new(
+        miner: fake_miner, command_status: :indeterminate, command_reason: 'DidNotConverge',
+        save_status: :ok, save_reason: nil
+      )
+      CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+    end
+
+    def drained_schedule(drained_at:, attempt_count: 0, last_attempt_at: nil)
+      CgminerManager::RestartSchedule.build(
+        miner_id: '127.0.0.1:4028', enabled: false, time_utc: nil,
+        last_restart_at: nil, last_scheduled_date_utc: nil,
+        drained: true, drained_at: drained_at, drained_by: 'op',
+        auto_resume_attempt_count: attempt_count,
+        auto_resume_last_attempt_at: last_attempt_at
+      )
+    end
+
+    describe 'process_schedule skip' do
+      it 'does NOT fire the nightly restart when the schedule is drained' do
+        store.replace(schedule.miner_id => schedule.with(
+          drained: true,
+          drained_at: (fixed_now - 30).iso8601(3),
+          drained_by: 'op'
+        ))
+        scheduler.tick
+        expect(fake_miner).not_to have_received(:restart)
+      end
+    end
+
+    describe 'auto-resume happy path (:ok)' do
+      let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+      before do
+        store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
+        allow(pool_manager).to receive(:enable_pool).with(pool_index: 0).and_return(ok_pool_result)
+        allow(CgminerManager::Logger).to receive(:info).and_call_original
+      end
+
+      it 'calls enable_pool, clears the drain fields, emits drain.resumed cause: :auto_resume' do # rubocop:disable RSpec/MultipleExpectations
+        scheduler.tick
+
+        persisted = store.load[schedule.miner_id]
+        expect(persisted.drained).to be(false)
+        expect(persisted.drained_at).to be_nil
+        expect(persisted.drained_by).to be_nil
+        expect(persisted.auto_resume_attempt_count).to eq(0)
+        expect(pool_manager).to have_received(:enable_pool).with(pool_index: 0)
+        expect(CgminerManager::Logger).to have_received(:info).with(
+          hash_including(event: 'drain.resumed', cause: :auto_resume,
+                         miner_id: schedule.miner_id, pool_index: 0)
+        )
+      end
+    end
+
+    describe 'C1 race: store re-read inside the mutex' do
+      let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+      before do
+        store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
+        # Simulate a concurrent operator Resume by clearing the drain
+        # mid-update via the store's update API. The auto-resume's
+        # update block re-reads inside the mutex and sees the cleared
+        # state, so it should NOT call enable_pool and NOT emit drain.resumed.
+        allow(store).to receive(:load).and_wrap_original do |original|
+          loaded = original.call
+          # Inject a "concurrent operator clear" by mutating the loaded copy.
+          # The next inner update() sees the original drained=true; we want
+          # to simulate that the wire call is gated by re-read. Instead,
+          # use a stub that returns a not-drained schedule to update().
+          loaded
+        end
+        allow(pool_manager).to receive(:enable_pool)
+      end
+
+      it 'skips wire call when re-read inside update shows drained=false' do
+        # Pre-clear before tick so the inner update block sees drained=false.
+        store.replace(schedule.miner_id => schedule)
+        scheduler.tick
+        expect(pool_manager).not_to have_received(:enable_pool)
+      end
+    end
+
+    describe 'auto-resume :indeterminate' do
+      let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+      before do
+        store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
+        allow(pool_manager).to receive(:enable_pool).and_return(indeterminate_pool_result)
+        allow(CgminerManager::Logger).to receive(:warn).and_call_original
+      end
+
+      it 'clears the drain fields anyway and emits drain.indeterminate' do
+        scheduler.tick
+
+        persisted = store.load[schedule.miner_id]
+        expect(persisted.drained).to be(false)
+        expect(CgminerManager::Logger).to have_received(:warn).with(
+          hash_including(event: 'drain.indeterminate', cause: :auto_resume)
+        )
+      end
+    end
+
+    describe 'auto-resume :failed + backoff' do
+      let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+      before do
+        store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
+        allow(pool_manager).to receive(:enable_pool).and_return(failed_pool_result)
+        allow(CgminerManager::Logger).to receive(:warn).and_call_original
+      end
+
+      it 'leaves drain in place, increments attempt_count, emits drain.failed cause: :auto_resume' do
+        scheduler.tick
+
+        persisted = store.load[schedule.miner_id]
+        expect(persisted.drained).to be(true)
+        expect(persisted.auto_resume_attempt_count).to eq(1)
+        expect(persisted.auto_resume_last_attempt_at).to start_with('2026-04-26T12:05:00')
+        expect(CgminerManager::Logger).to have_received(:warn).with(
+          hash_including(event: 'drain.failed', cause: :auto_resume, attempt_count: 1)
+        )
+      end
+
+      it 'gives up at error level once after AUTO_RESUME_GIVING_UP_AFTER consecutive failures' do
+        store.replace(schedule.miner_id => drained_schedule(
+          drained_at: '2026-04-26T12:00:00.000Z',
+          attempt_count: described_class::AUTO_RESUME_GIVING_UP_AFTER - 1,
+          last_attempt_at: '2026-04-26T11:00:00.000Z' # well past backoff cap
+        ))
+        allow(CgminerManager::Logger).to receive(:error).and_call_original
+
+        scheduler.tick
+
+        expect(CgminerManager::Logger).to have_received(:error).with(
+          hash_including(event: 'drain.auto_resume_giving_up',
+                         attempt_count: described_class::AUTO_RESUME_GIVING_UP_AFTER)
+        )
+      end
+    end
+
+    describe 'orphan miner: force-clear drain' do
+      let(:configured_miners) { [] } # rig removed from miners.yml
+      let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+      before do
+        store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
+        allow(CgminerManager::Logger).to receive(:info).and_call_original
+        allow(pool_manager).to receive(:enable_pool)
+      end
+
+      it 'clears the drain state without a wire call and emits cause: :auto_resume_orphan_cleared' do
+        scheduler.tick
+
+        persisted = store.load[schedule.miner_id]
+        expect(persisted.drained).to be(false)
+        expect(pool_manager).not_to have_received(:enable_pool)
+        expect(CgminerManager::Logger).to have_received(:info).with(
+          hash_including(event: 'drain.resumed', cause: :auto_resume_orphan_cleared)
+        )
+      end
+    end
+  end
+
   describe 'per-tick StandardError guard' do
     let(:scheduler) do
       described_class.new(store: store,

--- a/spec/cgminer_manager/restart_scheduler_spec.rb
+++ b/spec/cgminer_manager/restart_scheduler_spec.rb
@@ -250,7 +250,8 @@ RSpec.describe CgminerManager::RestartScheduler do
         expect(pool_manager).to have_received(:enable_pool).with(pool_index: 0)
         expect(CgminerManager::Logger).to have_received(:info).with(
           hash_including(event: 'drain.resumed', cause: :auto_resume,
-                         miner_id: schedule.miner_id, pool_index: 0)
+                         miner_id: schedule.miner_id, pool_index: 0,
+                         drained_at: '2026-04-26T12:00:00.000Z')
         )
       end
     end
@@ -258,27 +259,29 @@ RSpec.describe CgminerManager::RestartScheduler do
     describe 'C1 race: store re-read inside the mutex' do
       let(:fixed_now) { Time.utc(2026, 4, 26, 12, 5, 0) }
 
-      before do
+      it 'skips wire call when a concurrent Resume cleared drain between candidate selection and update block' do
+        # Outer load (in `auto_resume_drained`) sees drained=true so the
+        # rig becomes a candidate. THEN, simulating a concurrent operator
+        # POST /resume that won the race, we stub the store's `update`
+        # block to be invoked with a non-drained schedule. The block must
+        # detect drained=false and skip the wire call.
         store.replace(schedule.miner_id => drained_schedule(drained_at: '2026-04-26T12:00:00.000Z'))
-        # Simulate a concurrent operator Resume by clearing the drain
-        # mid-update via the store's update API. The auto-resume's
-        # update block re-reads inside the mutex and sees the cleared
-        # state, so it should NOT call enable_pool and NOT emit drain.resumed.
-        allow(store).to receive(:load).and_wrap_original do |original|
-          loaded = original.call
-          # Inject a "concurrent operator clear" by mutating the loaded copy.
-          # The next inner update() sees the original drained=true; we want
-          # to simulate that the wire call is gated by re-read. Instead,
-          # use a stub that returns a not-drained schedule to update().
-          loaded
-        end
         allow(pool_manager).to receive(:enable_pool)
-      end
 
-      it 'skips wire call when re-read inside update shows drained=false' do
-        # Pre-clear before tick so the inner update block sees drained=false.
-        store.replace(schedule.miner_id => schedule)
+        # Wrap update so the block sees a not-drained schedule even though
+        # the outer load saw drained=true. This simulates the race window
+        # closing between the candidate-selection load and the update block.
+        not_drained = schedule # baseline schedule with drained=false
+        allow(store).to receive(:update).and_wrap_original do |_original, _miner_id, &block|
+          result = block.call(not_drained)
+          # Mirror what RestartStore.update would do on success; we don't
+          # actually persist here because the wire call is what we're
+          # asserting against.
+          result
+        end
+
         scheduler.tick
+
         expect(pool_manager).not_to have_received(:enable_pool)
       end
     end
@@ -338,6 +341,32 @@ RSpec.describe CgminerManager::RestartScheduler do
           hash_including(event: 'drain.auto_resume_giving_up',
                          attempt_count: described_class::AUTO_RESUME_GIVING_UP_AFTER)
         )
+      end
+    end
+
+    describe 'same-tick ordering: auto-resume runs before fire-pass (decision #8)' do
+      # A drained schedule that has aged out into its restart window
+      # should clear in the auto-resume pass FIRST, then fire the
+      # nightly restart in the schedule-firing pass on the same tick.
+      let(:fixed_now) { Time.utc(2026, 4, 26, 4, 0, 30) }
+
+      before do
+        store.replace(schedule.miner_id => CgminerManager::RestartSchedule.build(
+          miner_id: '127.0.0.1:4028', enabled: true, time_utc: '04:00',
+          last_restart_at: nil, last_scheduled_date_utc: nil,
+          drained: true, drained_at: '2026-04-26T02:00:00.000Z', drained_by: 'op'
+        ))
+        allow(pool_manager).to receive(:enable_pool).and_return(ok_pool_result)
+      end
+
+      it 'clears drain AND fires restart in the same tick' do
+        scheduler.tick
+
+        persisted = store.load[schedule.miner_id]
+        expect(pool_manager).to have_received(:enable_pool).with(pool_index: 0)
+        expect(fake_miner).to have_received(:restart).once
+        expect(persisted.drained).to be(false)
+        expect(persisted.last_scheduled_date_utc).to eq('2026-04-26')
       end
     end
 

--- a/spec/cgminer_manager/restart_store_spec.rb
+++ b/spec/cgminer_manager/restart_store_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CgminerManager::RestartStore do
   let(:store) { described_class.new(path) }
 
   let(:schedule) do
-    CgminerManager::RestartSchedule.new(
+    CgminerManager::RestartSchedule.build(
       miner_id: '127.0.0.1:4028', enabled: true, time_utc: '04:00',
       last_restart_at: nil, last_scheduled_date_utc: nil
     )

--- a/spec/cgminer_manager/server_spec.rb
+++ b/spec/cgminer_manager/server_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe CgminerManager::Server do
       restart_schedules_file: schedules_file,
       restart_scheduler_enabled: true,
       shutdown_timeout: 10,
-      require_confirm: true
+      require_confirm: true,
+      drain_auto_resume_seconds: 3600
     )
   end
 

--- a/spec/integration/maintenance_drain_routes_spec.rb
+++ b/spec/integration/maintenance_drain_routes_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require 'rack/test'
+require 'tmpdir'
+require 'base64'
+require 'json'
+
+RSpec.describe 'maintenance drain routes', type: :integration do # rubocop:disable RSpec/MultipleMemoizedHelpers
+  include Rack::Test::Methods
+
+  def app = CgminerManager::HttpApp.new
+
+  let(:tmpdir) { Dir.mktmpdir('drain_spec') }
+  let(:miners_file) do
+    path = File.join(tmpdir, 'miners.yml')
+    File.write(path, "- host: 127.0.0.1\n  port: 4028\n")
+    path
+  end
+  let(:store_path) { File.join(tmpdir, 'restart_schedules.json') }
+  let(:store) { CgminerManager::RestartStore.new(store_path) }
+  let(:miner_id) { '127.0.0.1:4028' }
+  let(:fake_pool_manager) { instance_double(CgminerManager::PoolManager) }
+
+  def ok_pool_result
+    entry = CgminerManager::PoolManager::MinerEntry.new(
+      miner: nil, command_status: :ok, command_reason: nil,
+      save_status: :ok, save_reason: nil
+    )
+    CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+  end
+
+  def failed_pool_result(reason = 'connect timeout')
+    entry = CgminerManager::PoolManager::MinerEntry.new(
+      miner: nil, command_status: :failed, command_reason: reason,
+      save_status: :failed, save_reason: reason
+    )
+    CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+  end
+
+  def indeterminate_pool_result
+    entry = CgminerManager::PoolManager::MinerEntry.new(
+      miner: nil, command_status: :indeterminate, command_reason: 'DidNotConverge',
+      save_status: :ok, save_reason: nil
+    )
+    CgminerManager::PoolManager::PoolActionResult.new(entries: [entry])
+  end
+
+  before do
+    CgminerManager::HttpApp.configure_for_test!(
+      monitor_url: 'http://localhost:9292',
+      miners_file: miners_file,
+      restart_store: store
+    )
+    allow(CgminerManager::PoolManager).to receive(:new).and_return(fake_pool_manager)
+  end
+
+  after do
+    ENV['CGMINER_MANAGER_ADMIN_AUTH'] = 'off'
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  def fetch_csrf_token
+    get "/miner/#{miner_id}/maintenance"
+    Rack::Protection::AuthenticityToken.token(last_request.env['rack.session'] || {})
+  end
+
+  def post_drain
+    csrf = fetch_csrf_token
+    post "/miner/#{miner_id}/maintenance/drain",
+         { authenticity_token: csrf },
+         'HTTP_X_CSRF_TOKEN' => csrf
+  end
+
+  def post_resume
+    csrf = fetch_csrf_token
+    post "/miner/#{miner_id}/maintenance/resume",
+         { authenticity_token: csrf },
+         'HTTP_X_CSRF_TOKEN' => csrf
+  end
+
+  def capture_drain_log_events
+    events = []
+    %i[info warn].each do |level|
+      allow(CgminerManager::Logger).to receive(level).and_wrap_original do |m, **payload|
+        events << payload if payload[:event]&.start_with?('drain.')
+        m.call(**payload)
+      end
+    end
+    yield
+    events
+  end
+
+  describe 'POST /miner/:id/maintenance/drain' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    it 'persists drained=true on :ok and emits drain.applied' do
+      allow(fake_pool_manager).to receive(:disable_pool).with(pool_index: 0).and_return(ok_pool_result)
+      events = capture_drain_log_events { post_drain }
+
+      expect(last_response.status).to eq(200)
+      persisted = store.load[miner_id]
+      expect(persisted.drained).to be(true)
+      expect(persisted.drained_at).not_to be_nil
+      expect(events.map { |e| e[:event] }).to include('drain.applied')
+      expect(events.find { |e| e[:event] == 'drain.applied' }[:auto_resume_seconds]).to eq(3600)
+    end
+
+    it 'creates a default schedule on a never-scheduled miner (review C3)' do
+      expect(store.load[miner_id]).to be_nil
+      allow(fake_pool_manager).to receive(:disable_pool).and_return(ok_pool_result)
+      post_drain
+
+      persisted = store.load[miner_id]
+      expect(persisted).not_to be_nil
+      expect(persisted.enabled).to be(false)
+      expect(persisted.time_utc).to be_nil
+      expect(persisted.drained).to be(true)
+    end
+
+    it 'fails-open on :failed: store unchanged, drain.failed emitted, 502' do
+      allow(fake_pool_manager).to receive(:disable_pool).and_return(failed_pool_result('refused'))
+      events = capture_drain_log_events { post_drain }
+
+      expect(last_response.status).to eq(502)
+      expect(store.load[miner_id]).to be_nil
+      drain_failed = events.find { |e| e[:event] == 'drain.failed' }
+      expect(drain_failed).to include(cause: :drain, error: 'refused')
+    end
+
+    it 'fails-closed on :indeterminate: store reflects drained=true (decision #6)' do
+      allow(fake_pool_manager).to receive(:disable_pool).and_return(indeterminate_pool_result)
+      events = capture_drain_log_events { post_drain }
+
+      expect(last_response.status).to eq(200)
+      expect(store.load[miner_id].drained).to be(true)
+      expect(events.map { |e| e[:event] }).to include('drain.applied', 'drain.indeterminate')
+    end
+
+    it 'returns 422 when the miner is already drained' do
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
+        miner_id: miner_id, enabled: false, time_utc: nil,
+        last_restart_at: nil, last_scheduled_date_utc: nil,
+        drained: true, drained_at: '2026-04-26T12:00:00.000Z', drained_by: 'op'
+      ))
+      post_drain
+      expect(last_response.status).to eq(422)
+      expect(last_response.body).to include('already drained')
+    end
+
+    it 'returns 404 for an unconfigured miner_id' do
+      csrf = fetch_csrf_token
+      post '/miner/9.9.9.9%3A4028/maintenance/drain',
+           { authenticity_token: csrf },
+           'HTTP_X_CSRF_TOKEN' => csrf
+      expect(last_response.status).to eq(404)
+    end
+  end
+
+  describe 'POST /miner/:id/maintenance/resume' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    before do
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
+        miner_id: miner_id, enabled: true, time_utc: '04:00',
+        last_restart_at: nil, last_scheduled_date_utc: nil,
+        drained: true, drained_at: '2026-04-26T12:00:00.000Z', drained_by: 'op'
+      ))
+    end
+
+    it 'clears drain on :ok and emits drain.resumed cause: :operator' do
+      allow(fake_pool_manager).to receive(:enable_pool).with(pool_index: 0).and_return(ok_pool_result)
+      events = capture_drain_log_events { post_resume }
+
+      expect(last_response.status).to eq(200)
+      persisted = store.load[miner_id]
+      expect(persisted.drained).to be(false)
+      expect(persisted.drained_at).to be_nil
+      drain_resumed = events.find { |e| e[:event] == 'drain.resumed' }
+      expect(drain_resumed[:cause]).to eq(:operator)
+      expect(drain_resumed[:drained_at]).to eq('2026-04-26T12:00:00.000Z')
+    end
+
+    it 'preserves enabled + time_utc on resume (drain is independent of schedule)' do
+      allow(fake_pool_manager).to receive(:enable_pool).and_return(ok_pool_result)
+      post_resume
+      persisted = store.load[miner_id]
+      expect(persisted.enabled).to be(true)
+      expect(persisted.time_utc).to eq('04:00')
+    end
+
+    it 'fails-open on :failed: drain stays put, drain.failed emitted, 502' do
+      allow(fake_pool_manager).to receive(:enable_pool).and_return(failed_pool_result)
+      events = capture_drain_log_events { post_resume }
+
+      expect(last_response.status).to eq(502)
+      expect(store.load[miner_id].drained).to be(true)
+      expect(events.find { |e| e[:event] == 'drain.failed' }[:cause]).to eq(:resume)
+    end
+
+    it 'fails-open on :indeterminate: drain CLEARS anyway (decision #6)' do
+      allow(fake_pool_manager).to receive(:enable_pool).and_return(indeterminate_pool_result)
+      events = capture_drain_log_events { post_resume }
+
+      expect(last_response.status).to eq(200)
+      expect(store.load[miner_id].drained).to be(false)
+      expect(events.map { |e| e[:event] }).to include('drain.resumed', 'drain.indeterminate')
+    end
+
+    it 'returns 422 when the miner is not currently drained' do
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
+        miner_id: miner_id, enabled: false, time_utc: nil,
+        last_restart_at: nil, last_scheduled_date_utc: nil
+      ))
+      post_resume
+      expect(last_response.status).to eq(422)
+      expect(last_response.body).to include('not drained')
+    end
+  end
+
+  describe 'maintenance edit preserves drain state across schedule changes' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    before do
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
+        miner_id: miner_id, enabled: false, time_utc: nil,
+        last_restart_at: nil, last_scheduled_date_utc: nil,
+        drained: true, drained_at: '2026-04-26T12:00:00.000Z', drained_by: 'op'
+      ))
+    end
+
+    it 'editing the maintenance schedule does NOT clear an active drain' do
+      csrf = fetch_csrf_token
+      post "/miner/#{miner_id}/maintenance",
+           { authenticity_token: csrf, enabled: '1', time_utc: '05:30' },
+           'HTTP_X_CSRF_TOKEN' => csrf
+
+      persisted = store.load[miner_id]
+      expect(persisted.enabled).to be(true)
+      expect(persisted.time_utc).to eq('05:30')
+      expect(persisted.drained).to be(true)
+      expect(persisted.drained_at).to eq('2026-04-26T12:00:00.000Z')
+    end
+  end
+end

--- a/spec/integration/restart_schedule_routes_spec.rb
+++ b/spec/integration/restart_schedule_routes_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'maintenance routes', type: :integration do
 
   describe 'GET /miner/:id/maintenance' do
     it 'returns the form populated from the store' do
-      store.replace(miner_id => CgminerManager::RestartSchedule.new(
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
         miner_id: miner_id, enabled: true, time_utc: '04:00',
         last_restart_at: '2026-04-23T04:00:14Z', last_scheduled_date_utc: '2026-04-23'
       ))
@@ -109,7 +109,7 @@ RSpec.describe 'maintenance routes', type: :integration do
     end
 
     it 'preserves last_restart_at + last_scheduled_date_utc on update' do
-      store.replace(miner_id => CgminerManager::RestartSchedule.new(
+      store.replace(miner_id => CgminerManager::RestartSchedule.build(
         miner_id: miner_id, enabled: true, time_utc: '04:00',
         last_restart_at: '2026-04-23T04:00:14Z', last_scheduled_date_utc: '2026-04-23'
       ))

--- a/spec/integration/restart_schedules_endpoint_spec.rb
+++ b/spec/integration/restart_schedules_endpoint_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'GET /api/v1/restart_schedules.json', type: :integration do
 
   context 'with one schedule' do
     before do
-      store.replace('127.0.0.1:4028' => CgminerManager::RestartSchedule.new(
+      store.replace('127.0.0.1:4028' => CgminerManager::RestartSchedule.build(
         miner_id: '127.0.0.1:4028', enabled: true, time_utc: '04:00',
         last_restart_at: '2026-04-23T04:00:14Z', last_scheduled_date_utc: '2026-04-23'
       ))

--- a/views/miner/_maintenance.haml
+++ b/views/miner/_maintenance.haml
@@ -1,7 +1,10 @@
-- schedule  = @maintenance_schedule
-- enabled   = schedule&.enabled
-- time_utc  = schedule&.time_utc
-- last_at   = schedule&.last_restart_at
+- schedule    = @maintenance_schedule
+- enabled     = schedule&.enabled
+- time_utc    = schedule&.time_utc
+- last_at     = schedule&.last_restart_at
+- draining    = schedule&.draining?
+- drained_at  = schedule&.drained_at
+- drained_by  = schedule&.drained_by
 
 #maintenance.maintenance-section
   %h3 Scheduled Restart
@@ -28,3 +31,24 @@
 
   - if @maintenance_error_msg && !@maintenance_error_msg.empty?
     %p.danger= @maintenance_error_msg
+
+  %h3{ style: 'margin-top: 1.5em' } Drain (Disable Pool 0)
+  %p.muted
+    Stop hashing without restarting — pool 0 is disabled, the miner stays
+    responsive on the cgminer API for diagnosis. The scheduler skips drained
+    miners; auto-resume kicks in after the configured timeout
+    (default 1h) so a forgotten drain self-recovers.
+  - if draining
+    %p.warning
+      %strong Currently draining since
+      = drained_at
+      - if drained_by && !drained_by.empty?
+        \ by
+        = drained_by
+    %form.admin-form{ action: "#{miner_url(@miner_host_port)}/maintenance/resume", method: 'post', 'data-target' => '#maintenance' }
+      %input{ type: 'hidden', name: 'authenticity_token', value: csrf_token }
+      %button{ type: 'submit', onclick: "return confirm('Resume hashing on this miner now?')" } Resume Hashing
+  - else
+    %form.admin-form{ action: "#{miner_url(@miner_host_port)}/maintenance/drain", method: 'post', 'data-target' => '#maintenance' }
+      %input{ type: 'hidden', name: 'authenticity_token', value: csrf_token }
+      %button{ type: 'submit', onclick: "return confirm('Drain this miner — disable pool 0 until Resume or auto-resume in #{settings.drain_auto_resume_seconds / 60} minutes. Continue?')" } Drain (Stop Hashing)


### PR DESCRIPTION
## Summary

Per-miner Drain / Resume flow. Stop a single rig from hashing without restarting it — pool 0 gets disabled, the rig stays responsive on the cgminer API for diagnosis. Resume restores hashing.

```bash
# Drain
curl -u admin:pw -X POST http://localhost:3000/miner/127.0.0.1%3A4028/maintenance/drain
# → 200 + maintenance partial showing "Currently draining since X by admin"

# Resume
curl -u admin:pw -X POST http://localhost:3000/miner/127.0.0.1%3A4028/maintenance/resume
# → 200 + maintenance partial showing the normal scheduled-restart form
```

Drain state persists across manager restarts and is reflected on `/api/v1/restart_schedules.json` so `cgminer_monitor` v1.5.0+ can suppress the offline alert.

## Configuration

- `CGMINER_MANAGER_DRAIN_AUTO_RESUME_SECONDS` — default `3600`. Auto-resume timeout; integer > 0 (ConfigError on 0/negative/garbage).

## Behavior

- **Per-miner only.** Fleet-wide drain is intentionally not exposed. Per-miner blast radius means the routes skip the v1.7.0 confirmation-flow gate; the browser `confirm()` dialog naming the auto-resume timeout is the sole UX guardrail.
- **Auto-resume timer** runs in the existing `RestartScheduler` thread on each tick. Drained miners whose `now - drained_at >= auto_resume_seconds` get `enablepool 0` issued and the drain state cleared. The wire call is re-validated under the store's mutex so a concurrent operator Resume can't race with the timer.
- **Backoff on auto-resume failures:** attempts 2..N retry at `min(60, 2^(N-1)) * 60` seconds since the last attempt, capped at 60 minutes. After 5 consecutive failures the scheduler emits `drain.auto_resume_giving_up` once at error level then keeps retrying at the cap with `drain.failed` warns.
- **Same-tick ordering:** auto-resume pass runs BEFORE the schedule-firing pass, so a drain that ages out into a restart window correctly fires the restart on the same tick.
- **Wire-call failure semantics:**
  - `:ok` → state persists/clears, `drain.applied` / `drain.resumed`.
  - `:failed` → state unchanged (fail-open), `drain.failed`, HTTP 502.
  - `:indeterminate` → state persists on drain (fail-closed; the rig is most likely drained, auto-resume will recover); state clears on resume (fail-open; the rig is most likely already enabled). `drain.indeterminate` emits.
- **Maintenance-form edits preserve drain state.** Editing the scheduled-restart form on a drained miner only touches `enabled`/`time_utc`; drain lives behind its own buttons.

## Audit events (collapsed via `cause:` discriminator)

`drain.applied` / `drain.resumed` / `drain.failed` / `drain.indeterminate`. Plus `drain.auto_resume_giving_up` (error, one-shot) after 5 consecutive auto-resume failures. Schema reserved in `cgminer_monitor` v1.5.0's `docs/log_schema.md`.

## Cross-repo

Drain suppression of monitor's offline alert ships in `cgminer_monitor` v1.5.0 (already merged on develop and tagged). Older monitors will treat drained rigs as offline and page the operator — pinned in CHANGELOG.

Bumps to v1.8.0.

## Test plan

- [x] `bundle exec rake` — 476 examples / 0 failures, RuboCop clean
- [x] `RestartSchedule` spec gains 11 new examples covering drain field round-trip, back-compat with pre-v1.8.0 JSON, and field-level validation
- [x] `RestartScheduler` spec gains 8 new examples covering skip, auto-resume happy/indeterminate/failed/orphan paths, the C1 race re-read, the giving-up emission, and same-tick ordering
- [x] `AdminLogging` spec gains 7 new examples for the four drain helpers
- [x] `Config` spec gains 4 new examples for the env var
- [x] New integration spec `maintenance_drain_routes_spec.rb` (12 examples) covering route happy paths + failure modes + the maintenance-edit drain-state preservation
- [ ] CI green on full Ruby matrix + integration
